### PR TITLE
test function for conbined (concatenated) dataframe

### DIFF
--- a/casas_gis/parse_input.py
+++ b/casas_gis/parse_input.py
@@ -2,7 +2,7 @@
 (numbered) column names, number of rows, and the dictionary itself.
 """
 import os
-import glob
+from pathlib import Path
 import pandas as pd
 
 
@@ -26,7 +26,9 @@ def test_df_concat(input_folder=INPUT_FOLDER):
         and coefficient of variation of yearly values for multi year
         simulations."""
     df_dict = {}
-    for filepath in glob.iglob(f'{input_folder}/*.txt'):
+    # https://stackoverflow.com/a/10378012
+    pathlist = Path(input_folder).rglob('*.txt')
+    for filepath in pathlist:
         print(filepath)
         df = csv_to_df(filepath)
         get_df_info(df)
@@ -35,7 +37,7 @@ def test_df_concat(input_folder=INPUT_FOLDER):
         df_dict[dict_name] = df
     df_all = pd.concat(df_dict.values(), ignore_index=True)
     print('\n================================\n')
-    print('Following are info about conctatenated dataframe:\n')
+    print('Following is info about conctatenated dataframe:\n')
     get_df_info(df_all)
 
 


### PR DESCRIPTION
Wrapped some draft code I had that may be useful in the future for combining multiple yearly model outputs (CSV files) into a single one, based on which statistics can be computed across yearly simulations for each geographic location. Currently, this is done by an R script with a simple GUI to select a folder with CSV files. I am skipping this for now and moving onto the next important GIS functionality, as this is ancillary statistics functionality that can be addressed later/independently.

Still have to fix the `glob.iglob` thing with a more elegant option that you suggested:
>I find `pathlib` a bit nicer