### PR TITLE
started generating input files for GIS based on pandas dataframes

### DIFF
--- a/casas_gis/parse_input.py
+++ b/casas_gis/parse_input.py
@@ -2,15 +2,14 @@
 (numbered) column names, number of rows, and the dictionary itself.
 """
 import os
-import tempfile
 from pathlib import Path
 import pandas as pd
 
 
 INPUT_DIR = os.path.join(os.getcwd(), 'casas_gis/input_data')
-INPUT_DIR.mkdir(parents=True, exist_ok=True)
+os.makedirs(INPUT_DIR, exist_ok=True)
 TMP_DIR = os.path.join(os.getcwd(), 'casas_gis/tmp')
-TMP_DIR.mkdir(parents=True, exist_ok=True)
+os.makedirs(TMP_DIR, exist_ok=True)
 
 
 def csv_to_df(filepath):
@@ -22,16 +21,21 @@ def df_to_csv(df, filename, tmp_dir=TMP_DIR):
     df.to_csv(filepath, sep='\t')
 
 
-def get_df_info(df):
-    print('Dataframe head:\n')
-    print(df.head(), '\n')
-    rows, columns = df.shape
-    print(f'Dataframe has {rows} rows and {columns} columns.', '\n')
-    print('Dataframe basic info:\n')
-    return df.info()
+def get_df_info(df_dict):
+    for key, df in df_dict.items():
+        print(f'Head of {key} dataFrame:\n')
+        print(df.head(), '\n')
+        rows, columns = df.shape
+        print(f'{key} dataFrame has {rows} rows and {columns} columns.', '\n')
+        print(f'Basic info for {key} dataFrame:\n')
+        df.info()
+        print(f'\nEnd of {key} dataFrame info.')
+        print('===========================================================\n')
 
 
-def combine_dfs_to_dict(input_dir=INPUT_DIR):
+def csv_to_df_dict(input_dir=INPUT_DIR):
+    """ Turns CSV files in input_dir to a dictionary if dataFrames where
+        keys are the names of CSV files. Works with single CSV too."""
     df_dict = {}
     # https://stackoverflow.com/a/10378012 (glob directory)
     pathlist = Path(input_dir).rglob('*.txt')
@@ -44,7 +48,7 @@ def combine_dfs_to_dict(input_dir=INPUT_DIR):
 
 
 def concat_dfs(input_dir=INPUT_DIR):
-    df_dict = combine_dfs_to_dict(input_dir)
+    df_dict = csv_to_df_dict(input_dir)
     return pd.concat(df_dict.values(), ignore_index=True)
 
 
@@ -59,6 +63,7 @@ def extract_columns_from_df(df, column_id):
 
 
 def select_variable(df_dict, lon, lat, variable, tmp_dir=TMP_DIR):
+    # https://stackoverflow.com/a/55388872 (Loop through df_dict)
     for key, df in df_dict.items():
         lon_series = extract_columns_from_df(df, lon)
         lat_series = extract_columns_from_df(df, lat)
@@ -66,7 +71,7 @@ def select_variable(df_dict, lon, lat, variable, tmp_dir=TMP_DIR):
         df_select = pd.concat([lon_series,
                                lat_series,
                                variable_series], axis=1)
-        df_to_csv(df_select, key)
+    return df_select
 
 
 def test_df_concat(input_dir=INPUT_DIR):
@@ -82,7 +87,7 @@ def test_df_concat(input_dir=INPUT_DIR):
         get_df_info(df)
         dict_name = os.path.splitext(os.path.basename(filepath))[0]
         print('\nFile path is:\n', filepath)
-        print('\nDict name is:\n', dict_name)
+        print('\nDataFrame name is:\n', dict_name)
         print('\n================================\n')
         df_dict[dict_name] = df
     df_all = pd.concat(df_dict.values(), ignore_index=True)
@@ -91,6 +96,6 @@ def test_df_concat(input_dir=INPUT_DIR):
 
 
 if __name__ == "__main__":
-    test_df_concat()
-    dict_of_dataframes = combine_dfs_to_dict()
-    print(dict_of_dataframes)
+    # test_df_concat()
+    dict_of_dataframes = csv_to_df_dict()
+    get_df_info(dict_of_dataframes)


### PR DESCRIPTION
This is a first (untested) attempt at generating three-column CSV files to feed to the `v.in.ascii` GRASS GIS command. Probably,  I wrote too many functions as the `columns` argument of [`pandas.DataFrame.to_csv`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) would suffice.

So, a bit of an overkill, but I wanted to get some exercise and make the module more flexible (e.g., selects columns based on both numerical index or variable name).

Also, parse_input.py may now be split into e.g. parse_user_data.py and generate_gis_input.py
