### PR TITLE
Building a test environment for GIS commands

### DIFF
--- a/casas_gis/grass.py
+++ b/casas_gis/grass.py
@@ -1,14 +1,19 @@
 """ Geospatial functionality accessed through GRASSS GIS
-    https://grass.osgeo.org/grass79/manuals/libpython/index.html 
+    https://grass.osgeo.org/grass79/manuals/libpython/index.html
     Ideas for cloud implmentation:
     https://actinia.mundialis.de/api_docs/
     https://actinia.mundialis.de/tutorial/
     https://grasswiki.osgeo.org/wiki/GRASS_and_Python
     """
+
 import os
 import sys
 import atexit
-import grass.script as gs
+from grass_session import Session
+# see https://github.com/zarch/grass-session
+# http://osgeo-org.1560.x6.nabble.com/Using-grass-libraries-in-python-outside-of-GRASS-td5442894.html
+# http://osgeo-org.1560.x6.nabble.com/issue-with-grass-session-on-MacOSX-Cannot-find-GRASS-GIS-start-script-td5376619.html
+import grass.script import core as gcore
 
 
 # Clenaup routine?
@@ -19,4 +24,18 @@ import grass.script as gs
 #  using grassXY (i.e., hardcoding a specific GRASS version).
 # https://grass.osgeo.org/grass78/manuals/libpython/script.html#module-script.setup
 
-v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+def main():
+    """ Testing one GRASS command for setting up all required
+        environment."""
+    input_file = options['infile']
+    imported_map = options['outmap']
+
+    gcore.run_command("v.in.ascii",
+                      input=input_file,
+                      output=imported_map,
+                      fs="\t", x=1, y=2, z=0)
+
+
+if __name__ == "__main__":
+    options, flags = grass.parser()
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "grass-session"
+version = "0.5"
+description = "GRASS GIS session utilities"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "more-itertools"
 version = "8.8.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -166,7 +174,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "1da61a74d26e11fca668b47e924b3d18d77926da21c8fcdc410028047ac1fb63"
+content-hash = "16243bdf45fe7cd7cf4270588bfaf84c2c13d24e9d097bb8ae50de8aa0848c7f"
 
 [metadata.files]
 atomicwrites = [
@@ -183,6 +191,10 @@ colorama = [
 ]
 grass-script = [
     {file = "grass_script-0.0.4.tar.gz", hash = "sha256:fc7a29596caa95ed39b0ced4106fa437e0b59eea817662640f69aada4494e33b"},
+]
+grass-session = [
+    {file = "grass-session-0.5.tar.gz", hash = "sha256:7155314535790145da8e2e31b0d20cd2be91477d54083a738b5c319164e7f03b"},
+    {file = "grass_session-0.5-py2.py3-none-any.whl", hash = "sha256:ce03a53e28cc14bc7fff91482e83ed4f174a1325732c4333ed183dd15de39f8d"},
 ]
 more-itertools = [
     {file = "more-itertools-8.8.0.tar.gz", hash = "sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Luigi Ponti <quartese@gmail.com>"]
 python = "^3.8"
 pandas = "^1.2.5"
 grass-script = "^0.0.4"
+grass-session = "^0.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.6"


### PR DESCRIPTION
There are many pieces to the GRASS GIS puzzle when it comes to converting a bash script that calls GRASS commands without starting GRASS explicitly, to a similar Python script. The process is more complex also because the conversion occurs across major GRASS versions (i.e., version 7 to 8).

Bear with me… and be patience with the messy list of links in Python modules.