### PR TITLE
min/max check in bspline and abs raster stats

### DIFF
--- a/casas_gis/out/postscript/test_figure.eps
+++ b/casas_gis/out/postscript/test_figure.eps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%BoundingBox: 0 0 595 841                                                    
-%%Title: bicubic interpolation with Tykhonov regularization
+%%Title: 
 %%EndComments
 
 %%BeginProlog


### PR DESCRIPTION
- Check that interpolated raster from `v.surf.bspline` does not exceed range of input vector map.
- Compute max and min for set of raster maps being mapped for developing a single overall lenged that covers values across all maps in the set.