### PR TITLE
grassdata conversion scripts added

### DIFF
--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/README.md
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/README.md
@@ -1,0 +1,94 @@
+## Objectives
+
+The large GRASS GIS 6.4 database that CASAS has built so far, including
+geospatial information layers used for mapping and analysis by the
+extant CASAS geospatial software, has been migrated to GRASS GIS 8
+using a set of scripts as described below. The conversion scripts have
+been executed on the 45 GRASS GIS 6 formatted CASAS mapsets.
+
+## Vector data conversion
+
+The upgrade steps are (in a loop):
+
+- all maps: rebuilding of the vector topology from GRASS GIS 6 (a few
+  GRASS GIS 5 vector maps have been discovered as well) to GRASS GIS 8
+- all DBF-mapsets: attribute transfer from DBF to SQLite; susequent
+  deletion of `dbf/` subdirectory in respecive mapset if file is empty
+
+It took approx 40 min on an Intel Core i7 system to upgrade the GRASS
+GIS 6 vector data to GRASS GIS 8 including the rebuilding of vector
+topology and attribute transfer from DBF to SQLite.
+
+Observations:
+
+- a few isolated dbf files remained in a few mapsets which were unconnected
+  to vector maps
+- a few leftover files have been removed (apparently incompletely deleted
+  vector maps with only helper files left over; documented in the preparation script).
+- In the (few) mapsets which already used SQLite only the topology
+  has been rebuilt:
+  - Here the dbf files remained since no decision could be taken by the
+    contractor if the files are still relevant or not. They are easy to
+    spot by a file extension search.
+
+A conversion log file is generated for inspection.
+
+## Raster data conversion
+
+The upgrade steps were (in a loop):
+
+- set computational region to actual raster map
+- regenerate the map statistics
+
+Observations:
+
+- one raster map is using `r.external` (path: `/Users/luigi/olive_distribution_pnas.tif`) .
+  This map was not yet included in the Zenodo.org database. It could be
+  included and placed in the same mapset.
+
+It takes approx 15 min on an Intel Core i7 system to update the GRASS GIS 6
+raster statistics to GRASS GIS 8.
+
+A conversion log file is generated for inspection.
+
+## Developed scripts
+
+The scripts have been developed in a modular way.
+
+An approach to directly convert from GRASS GIS 6 to GRASS GIS 8 format
+has been identified.
+
+The subsequent scripts expect a GRASS GIS 8.4+ installation to be
+available on the machine.
+
+1\) Preprocessing script:
+
+- `process_grass6data_casas.sh`:
+  - unpacks GRASS GIS 6 database (ZIP format)
+  - informs user about next scripts to be run
+
+2\) Vector data upgrade script:
+
+- `vector_convert_all_mapsets_G6_G8.sh`:
+  - loops over all mapsets and runs:
+    - `v.db.dbf2sqlite.all.sh`:
+      - performs vector topology upgrade and migration from DBF
+        base attributes to SQLite
+
+Requirement:
+
+- `v.db.reconnect.all.py.diff`:
+  - note: a modification is needed in `v.db.reconnect.all` (GRASS
+    GIS 8) to turn fatal error existing on incomplete or already
+    SQLite-connected vector maps into a warning. Like this the
+    loop-oriented conversion continues.
+  - To be applied in the GRASS GIS source code with:
+    - `patch -p1 < v.db.reconnect.all.py.diff`
+
+3\) Raster data upgrade script:
+
+- `raster_convert_all_mapsets_G6_G8.sh`:
+  - loops over all mapsets and runs:
+    - `rsupport.stats.all.sh`:
+      - performs update of raster map statistics (including
+        creation of new internal files as per GRASS GIS 8).

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+############################################################################
+#
+# MODULE:       process_grass6data_casas.sh
+# AUTHOR(S):    Markus Neteler
+# PURPOSE:      Metascript to then run:
+#               - vector_convert_all_mapsets_G6_G8.sh which calls
+#                  - GRASS GIS and within v.db.dbf2sqlite.all.sh
+#               - raster_convert_all_mapsets_G6_G8.sh
+#                  - GRASS GIS and within r.support.stats.all.sh
+# REQUIREMENTS: patched version of v.db.reconnect.all.py (fatal -> warning)
+# COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
+#
+#		This program is free software under the GNU General Public
+#		License (>=v2). Read the file COPYING that comes with GRASS
+#		for details.
+#
+#############################################################################
+
+# cleanup previous run
+rm -rf ~/grass6data_casas
+
+# extract ZIP
+7z x ~/Downloads/casas_gis_old_grass6data_cleaned.zip
+
+cd ~/grass6data_casas/
+# remove garbage (dead, incomplete maps)
+rm -rf "AEA_Med/luigi/vector/clc00_v2_code_223_olive_points"
+rm -f "AEA_Med/luigi/cats/interpolMinSumLowMu_Plants_18Nov22_Avg (1)"
+
+echo "
+Next run (takes ~40 min on Intel Core i7):
+ sh ~/software/casas-gis/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
+
+and then run (takes ~15 min on Intel Core i7):
+ sh ~/software/casas-gis/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
+"

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+############################################################################
+#
+# MODULE:     r.support.stats.all.sh
+#             called by process_grass6data_casas.sh
+# AUTHOR(S):  Markus Neteler
+# PURPOSE:    update statistics of all raster maps in current mapset
+# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+#
+#		This program is free software under the GNU General Public
+#		License (>=v2). Read the file COPYING that comes with GRASS
+#		for details.
+#
+#############################################################################
+
+#%Module
+#%  description: Update statistics of all raster maps in current mapset.
+#%  keyword: raster
+#%  keyword: statistics
+#%end
+
+if  [ -z "$GISBASE" ] ; then
+ echo "You must be in GRASS GIS to run this program." >&2
+ exit 1
+fi
+
+# fail early
+#set -e  # commented to avoid stop at r.external error
+
+# get current mapset name as a var
+eval $(g.gisenv)
+# echo $LOCATION_NAME
+# echo $MAPSET
+
+export GRASS_MESSAGE_FORMAT=plain
+
+NUM=$(g.list type=raster mapset=. | wc -l)
+g.message message="Recomputing raster statistics for $NUM raster maps..."
+
+RASTMAPLIST=$(g.list type=raster mapset=.)
+for RASTMAP in $RASTMAPLIST ; do
+    g.region raster=$RASTMAP@$MAPSET  # needed for r.support -s?
+    r.support -s $RASTMAP@$MAPSET
+done

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+############################################################################
+#
+# MODULE:     raster_convert_all_mapsets_G6_G8.sh
+#             called by process_grass6data_casas.sh
+# AUTHOR(S):  Markus Neteler
+# PURPOSE:    updates raster statistics
+# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+#
+#		This program is free software under the GNU General Public
+#		License (>=v2). Read the file COPYING that comes with GRASS
+#		for details.
+#
+#############################################################################
+
+# fail early
+set -e
+
+export GRASS_MESSAGE_FORMAT=plain
+
+# log stdout and stderr into: conversion_raster.log
+# also show all in the terminal
+
+echo "Start: $(date)"
+# initiate new file
+echo "Start: $(date)" > conversion_raster.log
+
+cd ~/grass6data_casas/
+
+for LOC_MAPSET in $(find . -name WIND | sed 's+/WIND++g') ; do
+    echo "########### START Processing <$LOC_MAPSET>"
+    grass8.dev "$LOC_MAPSET" --exec r.support.stats.all.sh
+    echo "########### END Processing <$LOC_MAPSET>"
+done 2>&1 | tee -a conversion_raster.log
+
+echo "End: $(date)"
+echo "End: $(date)" >> conversion_raster.log
+
+echo "
+
+Conversion in all mapsets done.
+Log file written to <conversion_raster.log>
+"
+exit 0

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+############################################################################
+#
+# MODULE:       v.db.dbf2sqlite.all.sh, based on v.convert.all (GRASS GIS 6.4)
+# AUTHOR(S):    Markus Neteler
+# PURPOSE:      - rebuilds topology for all vector maps in current mapset
+#               - converts all old DBF-based GRASS GIS vector maps to SQLite DB
+#                 in current mapset. See:
+#                 https://grasswiki.osgeo.org/wiki/Convert_all_GRASS_6_vector_maps_to_GRASS_7
+#               - removes empty dbf/ directory
+# REQUIREMENTS: patched v.db.reconnect.all.py (fatal -> warning),
+#               see v.db.reconnect.all.py.diff
+# COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
+#
+#		This program is free software under the GNU General Public
+#		License (>=v2). Read the file COPYING that comes with GRASS
+#		for details.
+#
+#############################################################################
+
+#%Module
+#%  description: Converts all old DBF-based GRASS GIS vector maps to SQLite DB in current mapset.
+#%  keyword: vector
+#%  keyword: DBF
+#%  keyword: SQLite
+#%end
+
+if  [ -z "$GISBASE" ] ; then
+ echo "You must be in GRASS GIS to run this program." >&2
+ exit 1
+fi
+
+# fail early
+set -e
+
+# get current mapset name as a var
+eval $(g.gisenv)
+# echo $LOCATION_NAME
+# echo $MAPSET
+
+# check if the current mapset is still DBF based
+eval $(db.connect -g)
+# if no longer DBF then quit this conversion script
+if test "$driver" != "dbf"
+then
+    g.message message="Rebuilding topology for all vector maps in current mapset ... (1/1)"
+    # rebuild topology for all vector maps in current mapset
+    v.build.all
+    # attribute tables: nothing to do as SQLite already active in mapset
+    # still rm dbf/ dir, but only when empty (GRASS GIS vars from g.gisenv above)
+    [ "$(ls -A ${GISDBASE}/${LOCATION_NAME}/${MAPSET}/dbf 2>&1 /dev/null)" ] || rmdir ${GISDBASE}/${LOCATION_NAME}/${MAPSET}/dbf
+    g.message message="DBF driver not active in <${LOCATION_NAME}/${MAPSET}> (DB driver <$driver> found)"
+    g.message message="Skipping this mapset..."
+    exit 0
+else
+    # so we convert attibute tables to SQLite...
+    g.message message="Rebuilding topology for all vector maps in current mapset ... (1/3)"
+    # first rebuild topology for all vector maps in current mapset
+    v.build.all
+
+    g.message message="Define SQLite backend for vector maps in current mapset ... (2/3)"
+    # define new default DB connection (switch from DBF to SQLite)
+    db.connect -d
+
+    # print to verify new DB connection settings (should be SQLite)
+    db.connect -p
+
+    g.message message="Transfer all attribute tables from DBF to SQLite and clean old DBF tables in current mapset ... (3/3)"
+    # transfer all attribute tables from DBF to SQLite and clean old DBF tables
+    v.db.reconnect.all -cd
+    
+    # rm dbf/ dir, but only when empty (GRASS GIS vars from g.gisenv above)
+    [ "$(ls -A ${GISDBASE}/${LOCATION_NAME}/${MAPSET}/dbf 2>&1 /dev/null)" ] || rmdir ${GISDBASE}/${LOCATION_NAME}/${MAPSET}/dbf
+fi
+
+exit 0
+
+
+## test all vector maps in a mapset individually:
+# g.list type=vector mapset=. ; VECTMAPLIST=$(g.list type=vector mapset=.) ; eval $(g.gisenv) ; for VECTMAP in $VECTMAPLIST ; do v.db.connect -g $VECTMAP@$MAPSET  | cut -d'|' -f5 | grep sqlite > /dev/null || echo "$VECTMAP@$MAPSET is not DBF connected" ; done

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.reconnect.all.py.diff
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.reconnect.all.py.diff
@@ -1,0 +1,40 @@
+diff --git a/scripts/v.db.reconnect.all/v.db.reconnect.all.py b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+index b42b800667..1defe7d02f 100755
+--- a/scripts/v.db.reconnect.all/v.db.reconnect.all.py
++++ b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+@@ -19,6 +19,8 @@
+ # % keyword: vector
+ # % keyword: attribute table
+ # % keyword: database
++# % keyword: SQLite
++# % keyword: DBF
+ # %end
+ # %flag
+ # % key: c
+@@ -106,7 +108,7 @@ def create_db(driver, database):
+     try:
+         gs.run_command("db.createdb", driver=driver, database=subst_database)
+     except CalledModuleError:
+-        gs.fatal(
++        gs.warning(
+             _("Unable to create database <%s> by driver <%s>")
+             % (subst_database, driver)
+         )
+@@ -142,7 +144,7 @@ def copy_tab(from_driver, from_database, from_table, to_driver, to_database, to_
+             to_table=to_table,
+         )
+     except CalledModuleError:
+-        gs.fatal(_("Unable to copy table <%s>") % from_table)
++        gs.warning(_("Unable to copy table <%s>") % from_table)
+ 
+     return True
+ 
+@@ -171,7 +173,7 @@ def drop_tab(vector, layer, table, driver, database):
+             table=table,
+         )
+     except CalledModuleError:
+-        gs.fatal(_("Unable to drop table <%s>") % table)
++        gs.warning(_("Unable to drop table <%s>") % table)
+ 
+ 
+ # create index on key column

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+############################################################################
+#
+# MODULE:     vector_convert_all_mapsets_G6_G8.sh
+#             called by process_grass6data_casas.sh
+# AUTHOR(S):  Markus Neteler
+# PURPOSE:    converts all mapsets in current directory tree from
+#             old DBF-based GRASS GIS vector maps to SQLite DB
+# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+#
+#		This program is free software under the GNU General Public
+#		License (>=v2). Read the file COPYING that comes with GRASS
+#		for details.
+#
+#############################################################################
+
+# fail early
+set -e
+
+export GRASS_MESSAGE_FORMAT=plain
+
+# log stdout and stderr into: conversion_vector.log
+# also show all in the terminal
+
+echo "Start: $(date)"
+# initiate new file
+echo "Start: $(date)" > conversion_vector.log
+
+cd ~/grass6data_casas/
+
+for LOC_MAPSET in $(find . -name WIND | sed 's+/WIND++g') ; do
+    echo "########### START Processing <$LOC_MAPSET>"
+    grass8.dev "$LOC_MAPSET" --exec v.db.dbf2sqlite.all.sh
+    echo "########### END Processing <$LOC_MAPSET>"
+done 2>&1 | tee -a conversion_vector.log
+
+echo "End: $(date)"
+echo "End: $(date)" >> conversion_vector.log
+
+echo "
+
+Conversion in all mapsets done.
+Log file written to <conversion_vector.log>
+"
+exit 0


### PR DESCRIPTION
This PR adds a set of GRASS GIS 8 scripts used to convert the large GRASS GIS 6.4 database that CASAS has built so far to GRASS GIS 8. It converts raster data as well as vector data (topology update as well as attribute transfer from DBF to SQLite).

A `README.md` is included, describing the workflow.

A critical review is welcome.