### PR TITLE
GRASS GIS 8 related updates and variable usage

### DIFF
--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -27,7 +27,7 @@
 #
 # COPYRIGHT:    (c) 2005-2019 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
-#                       http://www.casasglobal.org/).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -206,7 +206,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -250,7 +250,7 @@
 
 # %flag
 # % key: p
-# % description: Produce bar chart plots summarizing raster statistics
+# % description: Produce barchart plots summarizing raster statistics
 # %end
 
 # %flag
@@ -258,8 +258,10 @@
 # % description: Save raster output as GeoTIFF
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -268,32 +270,33 @@ cleanup()
 {
 	# Remove temp directory.
 	\rm -rf $DIRTMP
-    # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	# Remove temp text files.
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+	\rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	g.mapset mapset=luigi location=AEA_Med
-	g.mremove -f vect=voronoi*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -310,7 +313,7 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
     exec g.parser "$0" "$@"
@@ -328,14 +331,14 @@ wait
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -410,14 +413,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR" > ~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -425,19 +428,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -447,8 +450,7 @@ g.mapset mapset=luigi location=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP;
-for i in `ls`;
-do
+for i in `ls`; do
 	echo "importing $i ...";
     v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
     wait;
@@ -479,54 +481,54 @@ if [ "$REG" == "-1" ] ; then
 # Map subset of countries
 elif [ "$REG" != "-1" ] ; then
 	# New clip based on countries
-	echo $REG > ~/clipRegion.txt;
-	perl ~/PerlScripts/cliparse_TC.pl "$HOME" "COUNTRY" 'string' "clipRegion.txt" "formula.txt"
+	echo $REG > ${OUTFILES}/clipRegion.txt;
+	perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" "COUNTRY" 'string' "clipRegion.txt" "formula.txt"
 	v.extract input=admin0_10m_naturalEarth_MED output=EtoSelect\
-		where="`cat ~/formula.txt`"
+		where="`cat ${OUTFILES}/formula.txt`"
 	v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1
 	# Adjust region settings
-	g.region vect=EtoSelect
+	g.region vector=EtoSelect
 	# For Canary Islands problem in Spain
 	if [ "$REG" == "Spain" ] ; then
 		g.region w=-2073635.08 s=-24171.35			
 	fi
 	# Make some room on the margins.
 	g.region n=n+50000 s=s-50000 e=e+50000 w=w-50000
-	g.region res=3000 -a		
+	g.region res=3000 -a
 fi
 
 # Use various crop growing areas for masking model output
 if [ "$CROP" == "grape" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && grape_growing_area_raster_below1000), Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && grape_growing_area_raster_below1000), Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_harvested" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_temperate" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_tropical" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_combined" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # No crop constraint
 elif [ "$CROP" == "none" ]; then
-	r.mapcalc ElevMask = 'if (EtoSelectMask, Med_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"	
+	r.mapcalc 'ElevMask = if (EtoSelectMask, Med_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 fi
 	
 	# Old clip based on ecological regions
-	# echo $REG > ~/clipRegion.txt;
-	# perl ~/PerlScripts/cliparse_TC.pl "$HOME" "GEZ_CODE" 'number' "clipRegion.txt" "formula.txt"
+	# echo $REG > ${OUTFILES}/clipRegion.txt;
+	# perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" "GEZ_CODE" 'number' "clipRegion.txt" "formula.txt"
 	# v.extract input=ecoZonesFaoEra40 output=EtoSelect\
-		# where="`cat ~/formula.txt`"
+		# where="`cat ${OUTFILES}/formula.txt`"
 	# v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1
 	# Get mask to clip sites with elevation over $ALT
 	# and outside selected ecological regions.
-	# r.mapcalc ElevMask = 'if (EtoSelectMask, Med_dem, null())'
-	# r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	# r.mapcalc 'ElevMask = if (EtoSelectMask, Med_dem, null())'
+	# r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 
 # Write header in the log file.
 echo "This log reports names of input files and full command used for analysis.
@@ -534,8 +536,8 @@ echo "This log reports names of input files and full command used for analysis.
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
-min=`cat ~/min.txt`;
-max=`cat ~/max.txt`;
+min=`cat ${OUTFILES}/min.txt`;
+max=`cat ${OUTFILES}/max.txt`;
 
 # Start interpolation process.
 cd $DIRTMP;
@@ -547,6 +549,7 @@ export GRASS_PNG_READ=TRUE
 export GRASS_RENDER_IMMEDIATE=TRUE
 export GRASS_TRUECOLOR=TRUE
 
+# Choose a font for figure text.
 export GRASS_FONT='arial'
 
 # d.erase color=white
@@ -599,23 +602,23 @@ do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"; wait;
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"; wait;
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+	# Set mask for interpolation.
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -629,32 +632,32 @@ do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
     d.erase color=white
-	
+
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt;
-	g.mremove -f vect=voronoi*;
+	\rm -f ${OUTFILES}/voronoi*.txt;
+	g.remove -f type=vector pattern="voronoi*";
 
     # If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -665,29 +668,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -701,29 +704,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -734,6 +737,7 @@ do
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
         # r.shaded.releif 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
         # Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -767,13 +771,13 @@ do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display true type font text in the legend (at x-y, coordinates).
-    echo "$LEG1" > ~/legend1.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt
 
-    Legend1="`cat ~/legend1.txt`"
-    Year="`cat ~/year$mapcycle.txt`"
-    echo $Legend1 $Year "($CROP)" > ~/legend1$mapcycle.txt
+    Legend1="`cat ${OUTFILES}/legend1.txt`"
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`"
+    echo $Legend1 $Year "($CROP)" > ${OUTFILES}/legend1$mapcycle.txt
     # Text for legend (at = percentage, x,y with [0,0] being left lower).
-	d.text size=4 color=black at=5,92 < ~/legend1$mapcycle.txt
+	d.text size=4 color=black at=5,92 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
 	# d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
@@ -836,8 +840,8 @@ do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy.
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -884,8 +888,8 @@ if [ "$GIS_FLAG_G" -eq 1 ] ; then
 	# d.vect map=map$i display=shape icon=basic/point size=20 layer=1\
 		# color=255:255:255 fcolor=0:0:0 width=2
 	# Weather="Weather stations";
-	# echo $Weather>~/weather.txt;
-	# d.text size=5 color=black at=5,92 <~/weather.txt;
+	# echo $Weather > ${OUTFILES}/weather.txt;
+	# d.text size=5 color=black at=5,92 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=gray bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -907,8 +911,8 @@ else
 	# d.vect map=map$i display=shape icon=basic/point size=20 layer=1\
 		# color=255:255:255 fcolor=0:0:0 width=2
 	# Weather="Weather stations";
-	# echo $Weather>~/weather.txt;
-	# d.text size=5 color=black at=5,92 <~/weather.txt;
+	# echo $Weather > ${OUTFILES}/weather.txt;
+	# d.text size=5 color=black at=5,92 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -932,46 +936,46 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}"
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}"
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 # Perform final cleanup.
 #~ cleanup
 
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ] ; then
-	for raster_outfile in `g.mlist rast pat="MskdModPOS*"` ; do
-		r.out.gdal input=$raster_outfile output=~/outfiles/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
+	for raster_outfile in `g.list raster pattern="MskdModPOS*"` ; do
+		r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
 	done
 fi
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -258,8 +258,11 @@
 # % description: Save raster output as GeoTIFF
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -2,7 +2,7 @@
 
 ############################################################################
 #
-# MODULE:       LybiaTunisia (Windows native version)
+# MODULE:       LibyaTunisia (Windows native version)
 #
 # AUTHOR(S):    Luigi Ponti lponti inbox com
 #
@@ -15,6 +15,7 @@
 #
 # COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -175,7 +176,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -227,8 +228,10 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -237,32 +240,33 @@ cleanup()
 {
 	# Remove temp directory.
 	\rm -rf $DIRTMP
-    # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	# Remove temp text files.
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+	\rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	g.mapset mapset=libya location=AEA_Med
-	g.mremove -f vect=voronoi*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -279,7 +283,7 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
     exec g.parser "$0" "$@"
@@ -296,14 +300,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -370,14 +374,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR" > ~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -385,19 +389,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -407,8 +411,7 @@ g.mapset mapset=luigi location=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP;
-for i in `ls`;
-do
+for i in `ls`; do
 	echo "importing $i ...";
     v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
     wait;
@@ -440,8 +443,8 @@ r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
-min=`cat ~/min.txt`;
-max=`cat ~/max.txt`;
+min=`cat ${OUTFILES}/min.txt`;
+max=`cat ${OUTFILES}/max.txt`;
 
 # Start interpolation process.
 cd $DIRTMP;
@@ -452,6 +455,7 @@ export GRASS_PNG_READ=TRUE
 export GRASS_RENDER_IMMEDIATE=TRUE
 export GRASS_TRUECOLOR=TRUE
 
+# Choose a font for figure text.
 export GRASS_FONT='arial'
 
 # d.erase color=white
@@ -502,23 +506,23 @@ do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl  "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"; wait;
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"; wait;
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+	# Set mask for interpolation.
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -528,25 +532,25 @@ do
     else
         # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i sie=69780 sin=69780 method=bicubic lambda_i=0.05 layer=1 column=$varType
-        r.mapcalc interpol$i = "if(ElevAltMask, interpolNoMask$i, null())"
+        r.mapcalc "interpol$i = if(ElevAltMask, interpolNoMask$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
     d.erase color=white
-	
+
 	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
 		# Set color table for interpolated raster
@@ -556,29 +560,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -592,29 +596,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -625,6 +629,7 @@ do
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
         # r.shaded.releif 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
         # Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -676,13 +681,13 @@ do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display true type font text in the legend (at x-y, coordinates).
-    echo "$LEG1" > ~/legend1.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt
 
-    Legend1="`cat ~/legend1.txt`"
-    Year="`cat ~/year$n.txt`"
-    echo $Legend1 $Year > ~/legend1$n.txt
+    Legend1="`cat ${OUTFILES}/legend1.txt`"
+    Year="`cat ${OUTFILES}/year$n.txt`"
+    echo $Legend1 $Year > ${OUTFILES}/legend1$n.txt
     # Text for legend (at= percentage, [0,0] is top left).
-	d.text size=5 color=black at=5,91 < ~/legend1$n.txt
+	d.text size=5 color=black at=5,91 input=${OUTFILES}/legend1$n.txt
 
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
 	# d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
@@ -700,7 +705,7 @@ do
 	
 	# If flag -r is checked, then write raster statistics.
 	if [ "$GIS_FLAG_R" -eq 1 ] ; then
-		r.report -en map=regioni_istat,MskdModPOS$i units=k,p nsteps=4>"$SaveDir"/$i.txt
+		r.report -en map=regioni_istat,MskdModPOS$i units=k,p nsteps=4 > "$SaveDir"/$i.txt
 		r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
 		if [ $n -eq 1 ] ; then
 			echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -725,8 +730,8 @@ do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -759,8 +764,8 @@ if [ "$GIS_FLAG_G" -eq 1 ] ; then
 		#~ color=255:255:255 fcolor=0:0:0
 	#~ d.font.freetype font="C:\Windows\Fonts\arial.ttf";
 	#~ Weather="Weather stations";
-	#~ echo $Weather>~/weather.txt;
-	#~ d.text size=5 color=black at=3,90 <~/weather.txt;
+	#~ echo $Weather > ${OUTFILES}/weather.txt;
+	#~ d.text size=5 color=black at=3,90 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=4:0:0 origin=0,0 color=gray bordercolor=black textcolor=black fontsize=15
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -801,38 +806,38 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 # Perform final cleanup.
 #~ cleanup
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -228,8 +228,11 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -230,8 +230,11 @@
 # % description: Map only inside olive growing area
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -10,13 +10,14 @@
 #                      to a GRASS monitor after interpolation and
 #                      save the map to an image file (currently png).
 #
-# NOTE:           This version supports outfiles with names of
+# NOTE:         This version supports outfiles with names of
 #                       type "Olive_02Mar06_00003.txt".
 #                       Voronoi part was reimplemented as in Mediterraneo
-#                       and flag -s removed because no longer used.          
+#                       and flag -s removed because no longer used.
 #
 # COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -133,7 +134,7 @@
 # %end
 
 # %option
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: color_rule_divergent
 # % type: string
 # % answer: 32:96:255-32:159:255-32:191:255-0:207:255-42:255:255-85:255:255-127:255:255-170:255:255-255:255:84-255:240:0-255:191:0-255:168:0-255:138:0-255:112:0-255:77:0-255:0:0
@@ -141,7 +142,7 @@
 # %end
 
 # %option
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: color_rule_regular
 # % type: string
 # % answer: 0:0:255-0:64:255-0:128:255-0:191:255-0:255:255-0:255:255-0:255:223-0:255:159-0:255:74-0:255:0-74:255:0-159:255:0-223:255:0-255:255:0-255:255:0-255:191:0-255:128:0-255:64:0-255:0:0
@@ -149,57 +150,57 @@
 # %end
 
 # %option
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: low_bar_col
 # % type: double
 # % description: Lower limit for legend color bar when -w option is enabled
 # %end
 
 # %option
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: up_bar_col
 # % type: double
 # % description: Upper limit for legend color bar when -w option is enabled
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: w
 # % description: Modify extent of legend color bar (using low and high input values)
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: g
 # % description: Black and white output instead of color
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: e
 # % description: Use histogram equalized color rule
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: l
 # % description: Logarithmic scaling
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: x
 # % description: Use an overall (compound) range for all maps (absolute max and min)
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: a
 # % description: Use also same legend bar for all maps (i.e. bar will extend to overall max and min)
 # %end
 
 # %flag
-# % guisection: Color_Rule
+# % guisection: Color rules
 # % key: d
 # % description: Use divergent, zero-centered color pattern (requires positive max and negative min)
 # %end
@@ -229,8 +230,10 @@
 # % description: Map only inside olive growing area
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -240,31 +243,32 @@ cleanup()
 	# Remove temp directory.
 	\rm -rf $DIRTMP
     # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+    \rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	g.mapset mapset=luigi location=AEA_Med
-	g.mremove -f vect=voronoi*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -281,7 +285,7 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
     exec g.parser "$0" "$@"
@@ -298,14 +302,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -372,14 +376,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR" > ~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl  "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -387,19 +391,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -409,8 +413,7 @@ g.mapset mapset=luigi location=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP;
-for i in `ls`;
-do
+for i in `ls`; do
 	echo "importing $i ...";
     v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
     wait;
@@ -431,7 +434,7 @@ g.mapset mapset=luigi location=AEA_Med
 g.region -a n=900000 s=-930000 e=2050000 w=-2343000 res=3000
 #~ Old region g.region -a n=1100000 s=-950000 e=2300000 w=-2343000 res=3000
 
-# Build a mask to select the region of interst to the study
+# Build a mask to select the region of interest to the study
 # based on FAO ecological regions. If -1 value is given, whole
 # region is used.
 
@@ -439,25 +442,25 @@ g.region -a n=900000 s=-930000 e=2050000 w=-2343000 res=3000
 if [ "$GIS_FLAG_M" -eq 1 ] ; then
     # Get mask to clip sites with elevation over $ALT
     # and outside selected ecological regions.
-    r.mapcalc ElevMask = 'if (olive_groves_new_raster_masked_below900, era40dem_resamp, null())'
-    r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+    r.mapcalc 'ElevMask = if (olive_groves_new_raster_masked_below900, era40dem_resamp, null())'
+    r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
     # Previous olive growing area: olive_density_contour_area_masked
 else
     if [ "$REG" == "-1" ] ; then
         v.to.rast input=ecoZonesFaoEra40 output=EtoSelectMask use=val value=1
         # Get mask to clip sites with elevation over $ALT
-        g.copy rast=era40dem_resamp,ElevMask
-        r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+        g.copy raster=era40dem_resamp,ElevMask
+        r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
     else
-        echo $REG > ~/clipRegion.txt;
-        perl ~/PerlScripts/cliparse_TC.pl "$HOME" "GEZ_CODE" 'number' "clipRegion.txt" "formula.txt"
+        echo $REG > ${OUTFILES}/clipRegion.txt;
+        perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" "GEZ_CODE" 'number' "clipRegion.txt" "formula.txt"
         v.extract input=ecoZonesFaoMedOlive output=EtoSelect\
-            where="`cat ~/formula.txt`"
+            where="`cat ${OUTFILES}/formula.txt`"
         v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1
         # Get mask to clip sites with elevation over $ALT
         # and outside selected ecological regions.
-        r.mapcalc ElevMask = 'if (EtoSelectMask, era40dem_resamp, null())'
-        r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+        r.mapcalc 'ElevMask = if (EtoSelectMask, era40dem_resamp, null())'
+        r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
     fi
 fi
 
@@ -465,8 +468,8 @@ fi
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
-min=`cat ~/min.txt`;
-max=`cat ~/max.txt`;
+min=`cat ${OUTFILES}/min.txt`;
+max=`cat ${OUTFILES}/max.txt`;
 
 # Start interpolation process.
 cd $DIRTMP;
@@ -477,6 +480,7 @@ export GRASS_PNG_READ=TRUE
 export GRASS_RENDER_IMMEDIATE=TRUE
 export GRASS_TRUECOLOR=TRUE
 
+# Choose a font for figure text.
 export GRASS_FONT='arial'
 
 # d.erase color=white
@@ -530,23 +534,23 @@ do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"; wait;
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"; wait;
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set map for interpolation.
-    g.copy rast=ElevAltMask,MASK
+    # Set mask for interpolation.
+    g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -556,28 +560,28 @@ do
     else
         # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i sie=69780 sin=69780 method=bicubic lambda_i=0.05 layer=1 column=$varType
-        r.mapcalc interpol$i = "if(ElevAltMask, interpolNoMask$i, null())"
+        r.mapcalc "interpol$i = if(ElevAltMask, interpolNoMask$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 	wait;
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
     d.erase color=white
-	
+
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt;
-	g.mremove -f vect=voronoi*;
+	\rm -f ${OUTFILES}/voronoi*.txt;
+	g.remove -f type=vector pattern="voronoi*";
 
     # If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -588,29 +592,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -624,29 +628,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -657,6 +661,7 @@ do
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
         # r.shaded.releif 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
         # Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -690,31 +695,31 @@ do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display true type font text in the legend (at x-y, coordinates).
-    echo "$LEG1" > ~/legend1.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt
 
-    Legend1="`cat ~/legend1.txt`"
-    Year="`cat ~/year$n.txt`"
-    echo $Legend1 $Year > ~/legend1$n.txt
+    Legend1="`cat ${OUTFILES}/legend1.txt`"
+    Year="`cat ${OUTFILES}/year$n.txt`"
+    echo $Legend1 $Year > ${OUTFILES}/legend1$n.txt
     # Text for legend (at= percentage, [0,0] is top left).
-	d.text size=5 color=black at=5,91 < ~/legend1$n.txt
+	d.text size=5 color=black at=5,91 input=${OUTFILES}/legend1$n.txt
 
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
 	# d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/"$i" res=$FIGRES format=eps
 	d.mon stop=PNG
 	# Write a log with names of input files.
-	echo "$i" | tee -a "$SaveDir"/"$LEG1".log
+	echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
 
     ###############
     # Raster statistics here  #    # Maybe do a test mapping cycle beforehand.
     ##############
 
-    # Raster statistics based on vector areas; histrogram by vector areas; what else?
+    # Raster statistics based on vector areas; histogram by vector areas; what else?
 	
 	# If flag -r is checked, then write raster statistics.
 	if [ "$GIS_FLAG_R" -eq 1 ] ; then
-		r.report -en map=regioni_istat,MskdModPOS$i units=k,p nsteps=4>"$SaveDir"/$i.txt
+		r.report -en map=regioni_istat,MskdModPOS$i units=k,p nsteps=4 > "$SaveDir"/$i.txt
 		r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
 		if [ $n -eq 1 ] ; then
 			echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -739,8 +744,8 @@ do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy.
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -773,8 +778,8 @@ if [ "$GIS_FLAG_G" -eq 1 ] ; then
 		#~ color=255:255:255 fcolor=0:0:0
 	#~ d.font.freetype font="C:\Windows\Fonts\arial.ttf";
 	#~ Weather="Weather stations";
-	#~ echo $Weather>~/weather.txt;
-	#~ d.text size=5 color=black at=3,90 <~/weather.txt;
+	#~ echo $Weather > ${OUTFILES}/weather.txt;
+	#~ d.text size=5 color=black at=3,90 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=gray bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -797,8 +802,8 @@ else
 		#~ color=255:255:255 fcolor=0:0:0;
 	#~ d.font.freetype font="C:\Windows\Fonts\arial.ttf";
 	#~ Weather="Weather stations";
-	#~ echo $Weather>~/weather.txt;
-	#~ d.text size=5 color=black at=3,90 <~/weather.txt;
+	#~ echo $Weather > ${OUTFILES}/weather.txt;
+	#~ d.text size=5 color=black at=3,90 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -822,38 +827,38 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}${LEG2}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}${LEG2}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}${LEG2}"
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}${LEG2}"
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 # Perform final cleanup.
 #~ cleanup
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -20,8 +20,8 @@
 #               2024-07-26 Ability to clip for cassava crop area
 #
 # COPYRIGHT:    (c) 2005-2024 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems
-#                       http://www.casasglobal.org/).
+#                       of Sustainable Agricultural Systems).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -200,7 +200,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -239,24 +239,23 @@
 
 # %flag
 # % key: r
-# % answer: 1
 # % description: Write a report with raster statistics
 # %end
 
 # %flag
 # % key: p
-# % answer: 1
-# % description: Produce bar chart plots summarizing raster statistics
+# % description: Produce barchart plots summarizing raster statistics
 # %end
 
 # %flag
 # % key: t
-# % answer: 1
 # % description: Save raster output as GeoTIFF
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -265,32 +264,33 @@ cleanup()
 {
 	# Remove temp directory.
 	\rm -rf $DIRTMP
-    # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	# Remove temp text files.
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+	\rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	g.mapset mapset=luigi location=africa_aea
-	g.mremove -f vect=voronoi*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -307,7 +307,7 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
     exec g.parser "$0" "$@"
@@ -325,14 +325,14 @@ wait
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -407,14 +407,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR" > ~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -422,19 +422,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -444,8 +444,7 @@ g.mapset mapset=luigi location=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP;
-for i in `ls`;
-do
+for i in `ls`; do
 	echo "importing $i ...";
     v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
     wait;
@@ -471,45 +470,45 @@ g.mapset mapset=luigi location=africa_aea
 # Map whole region
 if [ "$REG" == "-1" ] ; then
 	# Exclude some small off-coast islands
-	g.region vect=africa_region_box
+	g.region vector=africa_region_box
 	g.region -a res=3000
 	# Generate widest possible raster that will be mapped
 	v.to.rast input=africa output=EtoSelectMask use=val value=1
 # Map subset of countries
 elif [ "$REG" != "-1" ] ; then
 	# New clip based on countries
-	echo $REG > ~/clipRegion.txt;
-	perl ~/PerlScripts/cliparse_TC.pl "$HOME" "NAME_EN" 'string' "clipRegion.txt" "formula.txt"
+	echo $REG > ${OUTFILES}/clipRegion.txt;
+	perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" "NAME_EN" 'string' "clipRegion.txt" "formula.txt"
 	v.extract input=africa output=EtoSelect\
-		where="`cat ~/formula.txt`"
+		where="`cat ${OUTFILES}/formula.txt`"
 	# Adjust region settings
-	g.region vect=EtoSelect
+	g.region vector=EtoSelect
 	# Make some room on the margins.
 	g.region n=n+25000 s=s-25000 e=e+25000 w=w-25000
-	g.region -a res=3000		
+	g.region -a res=3000
 	v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1
 fi
 
 # Use various crop growing areas for masking model output
 if [ "$CROP" == "cassava" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && cassava_harvarea_binary), elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && cassava_harvarea_binary), elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_harvested" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_temperate" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_tropical" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_combined" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # No crop constraint
 elif [ "$CROP" == "none" ]; then
-	r.mapcalc ElevMask = 'if (EtoSelectMask, elevation_1KMmd_GMTEDmd, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"	
+	r.mapcalc 'ElevMask = if (EtoSelectMask, elevation_1KMmd_GMTEDmd, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 fi
 
 # Write header in the log file.
@@ -518,8 +517,8 @@ echo "This log reports names of input files and full command used for analysis.
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
-min=`cat ~/min.txt`;
-max=`cat ~/max.txt`;
+min=`cat ${OUTFILES}/min.txt`
+max=`cat ${OUTFILES}/max.txt`
 
 # Start interpolation process.
 cd $DIRTMP;
@@ -531,6 +530,7 @@ export GRASS_PNG_READ=TRUE
 export GRASS_RENDER_IMMEDIATE=TRUE
 export GRASS_TRUECOLOR=TRUE
 
+# Choose a font for figure text.
 export GRASS_FONT='arial'
 
 # d.erase color=white
@@ -583,23 +583,23 @@ do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"; wait;
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"; wait;
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+	# Set mask for interpolation.
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -613,37 +613,37 @@ do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
     d.erase color=white
-	
+
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt;
-	g.mremove -f vect=voronoi*;
+	\rm -f ${OUTFILES}/voronoi*.txt;
+	g.remove -f type=vector pattern="voronoi*";
 
 	# Land mask is required in Africa as raster layers are not clipped
 	r.mask input=africa_region_land
 
-    # If flag -g is checked, output is a greyscale figure
+	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
 		# Set color table for interpolated raster
 		# Do we want to use the same legend range for all maps?
@@ -652,29 +652,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -689,29 +689,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -722,6 +722,7 @@ do
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
         # r.shaded.releif 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
         # Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -738,7 +739,7 @@ do
 
 	# Display a legend for model raster with screen
     # coordinates as % of screen (bottom,top,left,right).
-	if [ "$GIS_FLAG_A" -eq 1 ] && [ "$GIS_FLAG_X" -eq 1 ] ; then		
+	if [ "$GIS_FLAG_A" -eq 1 ] && [ "$GIS_FLAG_X" -eq 1 ] ; then
 		d.legend -s map=MskdModPOS$i color=black lines=0\
 			thin=1000 labelnum=5 at=6,9,15,85 range="$min","$max" # absolute range.
     # Restrict width of color legend bar.
@@ -759,13 +760,13 @@ do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display true type font text in the legend (at x-y, coordinates).
-    echo "$LEG1" > ~/legend1.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt
 
-    Legend1="`cat ~/legend1.txt`"
-    Year="`cat ~/year$mapcycle.txt`"
-    echo $Legend1 $Year "($CROP)" > ~/legend1$mapcycle.txt
+    Legend1="`cat ${OUTFILES}/legend1.txt`"
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`"
+    echo $Legend1 $Year "($CROP)" > ${OUTFILES}/legend1$mapcycle.txt
     # Text for legend (at = percentage, x,y with [0,0] being left lower).
-	d.text size=4 color=black at=5,92 < ~/legend1$mapcycle.txt
+	d.text size=4 color=black at=5,92 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
 	# d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
@@ -828,8 +829,8 @@ do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy.
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -881,8 +882,8 @@ if [ "$GIS_FLAG_G" -eq 1 ] ; then
 	# d.vect map=map$i display=shape icon=basic/point size=20 layer=1\
 		# color=255:255:255 fcolor=0:0:0 width=2
 	# Weather="Weather stations";
-	# echo $Weather>~/weather.txt;
-	# d.text size=5 color=black at=5,92 <~/weather.txt;
+	# echo $Weather > ${OUTFILES}/weather.txt;
+	# d.text size=5 color=black at=5,92 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=gray bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -904,8 +905,8 @@ else
 	# d.vect map=map$i display=shape icon=basic/point size=20 layer=1\
 		# color=255:255:255 fcolor=0:0:0 width=2
 	# Weather="Weather stations";
-	# echo $Weather>~/weather.txt;
-	# d.text size=5 color=black at=5,92 <~/weather.txt;
+	# echo $Weather > ${OUTFILES}/weather.txt;
+	# d.text size=5 color=black at=5,92 input=${OUTFILES}/weather.txt;
 
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
 	# d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
@@ -932,46 +933,46 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}"
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}"
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 # Perform final cleanup.
 #~ cleanup
 
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ] ; then
-	for raster_outfile in `g.mlist rast pat="MskdModPOS*"` ; do
-		r.out.gdal input=$raster_outfile output=~/outfiles/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
+	for raster_outfile in `g.list raster pattern="MskdModPOS*"` ; do
+		r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
 	done
 fi
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -252,8 +252,11 @@
 # % description: Save raster output as GeoTIFF
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -280,8 +280,11 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -4,23 +4,23 @@
 #
 # MODULE:       india (Windows native version)
 #
-# AUTHOR(S):    Luigi Ponti
+# AUTHOR(S):    Luigi Ponti quartese gmail com
 #
 # PURPOSE:      Import ASCII ouput files from CASAS models
 #                      to a GRASS monitor after interpolation and
 #                      save the map to an image file (currently png).
 #
-# NOTE:           This version supports outfiles with names of
+# NOTE:         This version supports outfiles with names of
 #                       type "Cotton_02Mar06_00003.txt".
 #          
 #
 # COPYRIGHT:    (c) 2005-2013 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
 #		for details.
-#
 #
 #############################################################################
 
@@ -280,8 +280,10 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -291,34 +293,35 @@ cleanup()
 	# Remove temp directory.
 	\rm -rf $DIRTMP
     # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+    \rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=LAEA_India
-	g.mremove -f vect=voronoi*
-    g.mremove -f vect=selectedStates
-    g.mremove -f vect=Eto*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
-    g.mremove -f rast=selectedStatesRaster
+	g.mapset mapset=luigi location=LAEA_India
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=vector pattern="selectedStates"
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
+	g.remove -f type=raster pattern="selectedStatesRaster"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -335,10 +338,10 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
-	exec g.parser "$0" "$@"
+    exec g.parser "$0" "$@"
 fi
 
 if test "$GISBASE" = ""; then
@@ -352,14 +355,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -450,14 +453,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR">~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl  "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -465,19 +468,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -507,12 +510,12 @@ if [ "$STATES" = 'India' ] ; then
     FIGRES=1
     STATES='CH DL HP HR JK AP KL LD OR DN KA MH AS MN NL ML PB RJ UP UT JH WB BR SK CT MP PY TN GJ GA AR MZ TR DD'
     # Set region to all of India states and territories minus Andaman islands.
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "POSTAL" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "POSTAL" "states.txt" "formulaStates.txt"
     v.extract input=india_states output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
-    g.region vect=selectedStates
+    g.region vector=selectedStates
     # Make some room on the margins.
     g.region n=n+50000 s=s-50000 e=e+50000 w=w-50000
     g.region res=3000 -a
@@ -521,12 +524,12 @@ if [ "$STATES" = 'India' ] ; then
 else
     # Set region to an arbitrary subset of India states
     FIGRES=2
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "POSTAL" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "POSTAL" "states.txt" "formulaStates.txt"
     v.extract input=india_states output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
-    g.region vect=selectedStates
+    g.region vector=selectedStates
     # Make some room on the margins.
     g.region n=n+50000 s=s-50000 e=e+50000 w=w-50000
     g.region res=3000 -a
@@ -537,22 +540,22 @@ fi
 # Clip to various cotton cropping areas (or not)
 # Clip to cotton crop area
 if [ "$CLIP" = 'cotton_full' ] ; then
-    r.mapcalc EtoSelectMask = 'if(cotton_harea_175crops2000_india, selectedStatesRaster, null())'
+    r.mapcalc EtoSelectMask='if(cotton_harea_175crops2000_india, selectedStatesRaster, null())'
 # Clip to cotton crop area irrigated
 elif [ "$CLIP" = 'cotton_irrig' ] ; then
-    r.mapcalc EtoSelectMask = 'if(cotton_area_irrig_fraction_M3, selectedStatesRaster, null())'
+    r.mapcalc EtoSelectMask='if(cotton_area_irrig_fraction_M3, selectedStatesRaster, null())'
 # Clip to cotton crop area rainfed
 elif [ "$CLIP" = 'cotton_rainfed' ] ; then
-    r.mapcalc EtoSelectMask = 'if(cotton_area_rainf_fraction_M3, selectedStatesRaster, null())'
+    r.mapcalc EtoSelectMask='if(cotton_area_rainf_fraction_M3, selectedStatesRaster, null())'
 # No clip
 elif [ "$CLIP" = 'no_clip' ] ; then
-    g.copy rast=selectedStatesRaster,EtoSelectMask
+    g.copy raster=selectedStatesRaster,EtoSelectMask
 fi
 
 # Get mask to clip sites with elevation over $ALT
 # and outside selected ecological regions.
-r.mapcalc ElevMask = 'if (EtoSelectMask, india_dem, null())'
-r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+r.mapcalc 'ElevMask = if (EtoSelectMask, india_dem, null())'
+r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 
 # Write header in the log file.
 echo "This log reports names of input files and full command used for analysis.
@@ -560,8 +563,8 @@ echo "This log reports names of input files and full command used for analysis.
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing. Maybe check if the files exists...
-min=`cat ~/min.txt`
-max=`cat ~/max.txt`
+min=`cat ${OUTFILES}/min.txt`
+max=`cat ${OUTFILES}/max.txt`
 
 # Set size of output image.
 cd $DIRTMP
@@ -620,23 +623,23 @@ for i in `ls`; do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl  "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
     # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+    g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -649,18 +652,18 @@ for i in `ls`; do
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i \
         sie=$EAST_STEP sin=$NORTH_STEP method=bicubic \
         lambda_i=$TYKHONOV layer=1 column=$varType
-        r.mapcalc interpol$i = "if(ElevAltMask, interpolNoMask$i, null())"
+        r.mapcalc "interpol$i = if(ElevAltMask, interpolNoMask$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
@@ -669,8 +672,8 @@ for i in `ls`; do
     d.erase color=white
 
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt
-	g.mremove -f vect=voronoi*
+	\rm -f ${OUTFILES}/voronoi*.txt
+	g.remove -f type=vector pattern="voronoi*"
 
 	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -681,29 +684,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -720,29 +723,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -754,6 +757,7 @@ for i in `ls`; do
         # (this is supposed to make the shaded relief a bit less fuzzy -- step 3 NOT implemented here)
         # r.shaded.releif 60/315/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
 		# Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -789,19 +793,19 @@ for i in `ls`; do
     # d.barscale -l at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
-    echo "$LEG1" > ~/legend1.txt;
-    Legend1="`cat ~/legend1.txt`";
-    Year="`cat ~/year$n.txt`";
-    echo $Legend1 $Year > ~/legend1$n.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt;
+    Legend1="`cat ${OUTFILES}/legend1.txt`";
+    Year="`cat ${OUTFILES}/year$n.txt`";
+    echo $Legend1 $Year > ${OUTFILES}/legend1$n.txt
 
     # Text for legend (at= percentage, [0,0] is lower left).
-	d.text size=3 color=black at=5,94 < ~/legend1$n.txt
+	d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$n.txt
 
     # Save display to .png file.
 	d.mon stop=PNG
-	
+
 	# Write a log with names of input files.
-	echo "$i" | tee -a "$SaveDir"/"$LEG1".log
+	echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
 
     ###############
@@ -855,7 +859,7 @@ for i in `ls`; do
         eval `r.univar -g -e map="MskdModPOS$i"`	
         iqr_low=`perl -E "say "$first_quartile" - (("$third_quartile" - "$first_quartile") * 1.5)"`
         iqr_high=`perl -E "say "$third_quartile" + (("$third_quartile" - "$first_quartile") * 1.5)"`
-        r.mapcalc MskdIQR$i = "if((MskdModPOS$i > $iqr_low && MskdModPOS$i < $iqr_high), MskdModPOS$i, null())"
+        r.mapcalc MskdIQR$i="if((MskdModPOS$i > $iqr_low && MskdModPOS$i < $iqr_high), MskdModPOS$i, null())"
         eval `r.univar -g -e map="MskdIQR$i"`
         whisker1=$min
         whisker2=$max
@@ -879,8 +883,8 @@ for i in `ls`; do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -893,7 +897,7 @@ for i in `ls`; do
     # Remove temporary ascii files produced by PERL script "convert.pl".
     rm $i
 
-    let  mapcycle++;
+    let mapcycle++;
 done
 
 # Write full command line to log.
@@ -956,7 +960,7 @@ else
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
     d.erase color=white
-    r.mapcalc selectedStates.composite = 'if(selectedStatesRaster, natural_earth_color.composite, null())'
+    r.mapcalc 'selectedStates.composite = if(selectedStatesRaster, natural_earth_color.composite, null())'
     r.colors map=selectedStates.composite raster=natural_earth_color.composite
     d.his i=india_shaded_60_315_10 h=selectedStates.composite
     d.vect map=india_region_world_bounds type=boundary color=150:150:150 width=2
@@ -987,36 +991,36 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -10,17 +10,17 @@
 #                      to a GRASS monitor after interpolation and
 #                      save the map to an image file (currently png).
 #
-# NOTE:           This version supports outfiles with names of
+# NOTE:         This version supports outfiles with names of
 #                       type "Olive_02Mar06_00003.txt".
 #          
 #
 # COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
 #		for details.
-#
 #
 #############################################################################
 
@@ -186,7 +186,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -238,6 +238,9 @@
 # % description: Map only inside grape growing area
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
@@ -249,30 +252,31 @@ cleanup()
 	# Remove temp directory.
 	\rm -rf $DIRTMP
 	# Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	g.mapset mapset=luigi location=EurLCC
-	g.mremove -f vect=voronoi*
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -289,10 +293,10 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
-	exec g.parser "$0" "$@"
+    exec g.parser "$0" "$@"
 fi
 
 if test "$GISBASE" = ""; then
@@ -306,33 +310,33 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir"
 	fi
 fi
 
 # Set user-defined X, Y, mapping parameter, etc.
 if [ -n "$GIS_OPT_LONGITUDE" ] ; then
-	LON=$GIS_OPT_LONGITUDE
+	LON="$GIS_OPT_LONGITUDE"
 fi
 
 if [ -n "$GIS_OPT_LATITUDE" ] ; then
-    LAT=$GIS_OPT_LATITUDE
+    LAT="$GIS_OPT_LATITUDE"
 fi
 
 if [ -n "$GIS_OPT_YEAR" ] ; then
-    YEAR=$GIS_OPT_YEAR
+    YEAR="$GIS_OPT_YEAR"
 fi
 
 if [ -n "$GIS_OPT_PARAMETER" ] ; then
-    PAR=$GIS_OPT_PARAMETER
+    PAR="$GIS_OPT_PARAMETER"
 fi
 
 if [ -n "$GIS_OPT_INTERPOLATION" ] ; then
@@ -344,27 +348,27 @@ if [ -n "$GIS_OPT_NUMPOINTS" ] ; then
 fi
 
 if [ -n "$GIS_OPT_LOWERCUT" ] ; then
-	CUT=$GIS_OPT_LOWERCUT
+	CUT="$GIS_OPT_LOWERCUT"
 fi
 
 if [ -n "$GIS_OPT_UPPERCUT" ] ; then
-	HICUT=$GIS_OPT_UPPERCUT
+	HICUT="$GIS_OPT_UPPERCUT"
 fi
 
 if [ -n "$GIS_OPT_LEGEND" ] ; then
-    LEG=$GIS_OPT_LEGEND
+    LEG="$GIS_OPT_LEGEND"
 fi
 
 if [ -n "$GIS_OPT_REGION" ] ; then
-    REG=$GIS_OPT_REGION
+    REG="$GIS_OPT_REGION"
 fi
 
 if [ -n "$GIS_OPT_ALT" ] ; then
-    ALT=$GIS_OPT_ALT
+    ALT="$GIS_OPT_ALT"
 fi
 
 if [ -n "$GIS_OPT_RESOLUTION" ] ; then
-    FIGRES=$GIS_OPT_RESOLUTION
+    FIGRES="$GIS_OPT_RESOLUTION"
 fi
 
 if [ -n "$GIS_OPT_COLORRULEDIVERGENT" ] ; then
@@ -384,14 +388,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR">~/inputPar.txt;
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt;
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl "$HOME"; wait;
+perl ${PERLSCRIPTS}/printYear.pl "$HOME"; wait;
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convertITA.pl "$HOME"; wait;
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"; wait;
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -399,19 +403,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -421,8 +425,7 @@ g.mapset mapset=luigi location=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP;
-for i in `ls`;
-do
+for i in `ls`; do
 	echo "importing $i ...";
     v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0;
     wait;
@@ -444,10 +447,10 @@ g.region res=1000
 # Build a mask to select the region of interst to the study
 # based on Italian admnistrative regions (ISTAT codes).
 cd $GISDBASE;
-echo $REG>~/clipRegion.txt;
-perl ~/PerlScripts/cliparseITA.pl "$HOME"
+echo $REG>${OUTFILES}/clipRegion.txt;
+perl ${PERLSCRIPTS}/cliparseITA.pl "$HOME"
 v.extract input=regioni_istat output=EtoSelect\
-    where="`cat ~/formula.txt`";
+    where="`cat ${OUTFILES}/formula.txt`";
 v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1;
 
 g.region -a vect=EtoSelect
@@ -463,14 +466,14 @@ fi
 
 # Get mask to clip sites with elevation over $ALT
 # and outside selected administrative regions.
-r.mapcalc ElevMask = 'if (EtoSelectMask, g10g, null())';
-r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())";
+r.mapcalc 'ElevMask = if (EtoSelectMask, g10g, null())';
+r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())";
 
 # Write header in the log file.
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"$LEG".log;
 # Retrieve range min and max values for possible use in legend drawing.
-min=`cat ~/min.txt`;
-max=`cat ~/max.txt`;
+min=`cat ${OUTFILES}/min.txt`;
+max=`cat ${OUTFILES}/max.txt`;
 
 # Set size of output image.
 cd $DIRTMP;
@@ -532,20 +535,20 @@ do
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi; wait;
-	v.category option=print input=mapZero$i > ~/voronoi.txt; wait;
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt; wait;
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt; wait;
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt; wait;
 	fi
-	perl ~/PerlScripts/voroparse.pl "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl "$HOME"
 	v.extract input=voronoi output=voronoiSel\
-        where="`cat ~/voronoiFormula.txt`"; wait;
+        where="`cat ${OUTFILES}/voronoiFormula.txt`"; wait;
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1; wait;
-	
+
 	# Set a proper MASK to speed up interpolation process.
-	g.copy rast=ElevAltMask,MASK
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -559,26 +562,26 @@ do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi	
-	
+
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
-	
-	if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())";
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())";
+	g.remove -f type=raster name=MASK
+
+	if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())";
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())";
     else
-		g.copy rast=interpol$i,MskdModPOS$i; wait;
+		g.copy raster=interpol$i,MskdModPOS$i; wait;
     fi
 	
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt;
-	g.mremove -f vect=voronoi*;
+	\rm -f ${OUTFILES}/voronoi*.txt;
+	g.remove -f type=vector pattern="voronoi*";
 
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
@@ -594,29 +597,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -634,29 +637,29 @@ do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -693,14 +696,14 @@ do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 	
     # Display true type font text in the legend (at x-y, lower-left coordinates).
-    echo $LEG > ~/legend.txt;
+    echo $LEG > ${OUTFILES}/legend.txt;
 
-	Legend="`cat ~/legend.txt`";
-    Year="`cat ~/year$mapcycle.txt`";
-    echo $Legend $Year>~/legend$mapcycle.txt;
+    Legend="`cat ${OUTFILES}/legend.txt`";
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`";
+    echo $Legend $Year>${OUTFILES}/legend$mapcycle.txt;
 
     # Text for legend (at= percentage, [0,0] is lower left).
-	d.text size=3 color=black at=5,94 < ~/legend$mapcycle.txt
+	d.text size=3 color=black at=5,94 input=${OUTFILES}/legend$mapcycle.txt
 
     # Save display to .png file.
 	d.mon stop=PNG
@@ -750,8 +753,8 @@ do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy.
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -770,7 +773,7 @@ done
 # Write full command line to log.
 cat >> "$SaveDir"/"${LEG}".log <<EOF
 
-GIS script sintax used:
+GIS script syntax used:
 
     EurMedGrape
     w=$GIS_FLAG_W g=$GIS_FLAG_G e=$GIS_FLAG_E l=$GIS_FLAG_L
@@ -784,7 +787,7 @@ GIS script sintax used:
 EOF
 
 # Write date in the log file.
-echo "(`date -R | tr -s ' ' ' '`)" | tee -a "$SaveDir"/"$LEG".log;
+echo "(`date -R | tr -s ' ' ' '`)" | tee -a "$SaveDir"/"${LEG}".log;
 
 # Display & save a map with weather stations used for analysis.
 # If flag -g is checked, output is a greyscale figure (no lakes)
@@ -823,7 +826,7 @@ else
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
 	# d.mon stop=x0
     d.barscale -s at=2,90 fontsize=25
-		
+
     d.mon stop=PNG
 fi
 
@@ -841,39 +844,39 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "$LEG" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "$LEG" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots";
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "$LEG";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "$LEG";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 # Perform final cleanup.
 #~ cleanup
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/$LEG.html"

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -238,8 +238,11 @@
 # % description: Map only inside grape growing area
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -274,8 +274,11 @@
 # % description: Save raster output as GeoTIFF
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -34,7 +34,7 @@
 #
 # COPYRIGHT:    (c) 2005-2021 CASAS Global (Center for the Analysis
 #                       of Sustainable Agricultural Systems Global
-#                       http://www.casasglobal.org/).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -266,7 +266,7 @@
 
 # %flag
 # % key: p
-# % description: Produce bar chart plots summarizing raster statistics
+# % description: Produce barchart plots summarizing raster statistics
 # %end
 
 # %flag
@@ -274,8 +274,10 @@
 # % description: Save raster output as GeoTIFF
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -285,33 +287,34 @@ cleanup()
 	# Remove temp directory.
 	\rm -rf $DIRTMP
     # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+    \rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=medgold location=latlong_medgold
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
-    g.mapset mapset=medgold location=laea_andalusia
-	g.mremove -f vect=voronoi*
-    g.mremove -f vect=selectedStates
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
-    g.mremove -f rast=selectedStatesRaster
+	g.mapset mapset=medgold location=laea_andalusia
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=vector pattern="selectedStates"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
+	g.remove -f type=raster pattern="selectedStatesRaster"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -328,10 +331,10 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
-	exec g.parser "$0" "$@"
+    exec g.parser "$0" "$@"
 fi
 
 if test "$GISBASE" = ""; then
@@ -345,14 +348,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -431,13 +434,13 @@ if [ -n "$GIS_OPT_RESOLUTION" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR">~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl  "$HOME"
 
 # Run a perl script that gets rid of column names
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -445,19 +448,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -485,7 +488,7 @@ g.mapset mapset=medgold location=laea_andalusia
 # Selection of based on vector areas.
 if [ "$PROVINCES" = 'all' ] ; then
 	# Full region for the Andalusia mapping routine
-	g.region vect=andalusia_provinces
+	g.region vector=andalusia_provinces
 	v.to.rast input=andalusia_provinces output=EtoSelectMask use=val value=1
 	# Make some room on the margins
 	g.region n=n+7000 s=s-7000 e=e+7000 w=w-7000
@@ -493,10 +496,10 @@ if [ "$PROVINCES" = 'all' ] ; then
 	g.region -a res=1000
 else
     # Set region to an arbitrary subset of provinces
-    echo $PROVINCES>~/states.txt
-    perl ~/PerlScripts/cliparse_TC.pl "$HOME" 'iso_3166_2' 'string' "states.txt" "formulaStates.txt"
+    echo $PROVINCES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" 'iso_3166_2' 'string' "states.txt" "formulaStates.txt"
     v.extract input=andalusia_provinces output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=EtoSelectMask use=val value=1
@@ -508,24 +511,24 @@ fi
 
 # Use various olive growing areas for masking model output
 if [ "$CROP" == "olive" ]; then
-	r.mapcalc ElevMask = "if ((EtoSelectMask && olive_HarvestedAreaFraction_andalusia > $CROP_THRESHOLD), elevation_1KMmd_GMTEDmd_andalusia, null())"
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc "ElevMask = if ((EtoSelectMask && olive_HarvestedAreaFraction_andalusia > $CROP_THRESHOLD), elevation_1KMmd_GMTEDmd_andalusia, null())"
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use SIGPAC olive monocolture data (resampled at 3 km)
 elif [ "$CROP" == "sigpac" ]; then	
-	r.mapcalc ElevMask = "if ((EtoSelectMask && olive_monoculture_sigpac_2018_3km == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc "ElevMask = if ((EtoSelectMask && olive_monoculture_sigpac_2018_3km == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use SIGPAC olive monocolture data (r.grow with 5km buffer radius)
 elif [ "$CROP" == "sigpac_buffered_5km" ]; then	
-	r.mapcalc ElevMask = "if ((EtoSelectMask && olive_monoculture_sigpac_2018_grow_5000 == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc "ElevMask = if ((EtoSelectMask && olive_monoculture_sigpac_2018_grow_5000 == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use SIGPAC olive monocolture data (r.grow with 3km buffer radius)
 elif [ "$CROP" == "sigpac_buffered_3km" ]; then	
-	r.mapcalc ElevMask = "if ((EtoSelectMask && olive_monoculture_sigpac_2018_grow_3000 == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc "ElevMask = if ((EtoSelectMask && olive_monoculture_sigpac_2018_grow_3000 == 1), elevation_1KMmd_GMTEDmd_andalusia, null())"
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use no mask for model output
 elif [ "$CROP" == "none" ]; then
-	r.mapcalc ElevMask = 'if (EtoSelectMask, elevation_1KMmd_GMTEDmd_andalusias, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"	
+	r.mapcalc 'ElevMask = if (EtoSelectMask, elevation_1KMmd_GMTEDmd_andalusias, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"	
 fi
 
 # Write header in the log file.
@@ -533,8 +536,8 @@ echo "This log reports names of input files used for analysis:" | tee -a "$SaveD
 
 # Retrieve range min and max values for possible use in legend drawing.
 # Maybe check if the files exists...
-abs_min=`cat ~/min.txt`
-abs_max=`cat ~/max.txt`
+abs_min=`cat ${OUTFILES}/min.txt`
+abs_max=`cat ${OUTFILES}/max.txt`
 
 # Set size of output image.
 cd $DIRTMP
@@ -552,7 +555,7 @@ for i in `ls`; do
 	# Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
     v.proj input=map$i location=latlong_medgold mapset=medgold\
-		output=map$i		
+		output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -585,31 +588,31 @@ for i in `ls`; do
     # Extract points lower than cutting point to map them with a different symbol.
     v.extract input=map$i output=mapZero$i \
         where="($varType < $CUT)"
-	
+
     # Extract points higher than upper cutting point to map them with a different symbol.
     v.extract input=map$i output=mapHigh$i \
         where="($varType > $HICUT)"
-	
+
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
     # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+    g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -623,32 +626,32 @@ for i in `ls`; do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
-		
+
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
     d.erase color=white
 
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt
-	g.mremove -f vect=voronoi*
+	\rm -f ${OUTFILES}/voronoi*.txt
+	g.remove -f type=vector pattern="voronoi*"
 
 	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -659,29 +662,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -698,29 +701,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -761,13 +764,13 @@ for i in `ls`; do
     # d.barscale -l at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
-    echo "$LEG1" > ~/legend1.txt;
-    Legend1="`cat ~/legend1.txt`";
-    Year="`cat ~/year$mapcycle.txt`";
-    echo $Legend1 $Year "($CROP)" > ~/legend1$mapcycle.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt;
+    Legend1="`cat ${OUTFILES}/legend1.txt`";
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`";
+    echo $Legend1 $Year "($CROP)" > ${OUTFILES}/legend1$mapcycle.txt
 
     # Text for legend (at= percentage, [0,0] is lower left).
-	d.text size=3 color=black at=5,94 < ~/legend1$mapcycle.txt
+	d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
 	d.mon stop=PNG
@@ -823,8 +826,8 @@ for i in `ls`; do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -881,7 +884,7 @@ else
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
     d.erase color=white
-    r.mapcalc selectedStates.composite = 'if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_andalusia_250m, null())'
+    r.mapcalc 'selectedStates.composite = if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_andalusia_250m, null())'
     r.colors map=selectedStates.composite raster=NE1_HR_LC_SR_W_DR.composite_andalusia_250m
     d.his i=SR_HR_andalusia_clip_250m h=selectedStates.composite brighten=5
     d.vect map=ne_10m_coastline_andalusia type=boundary color=150:150:150 width=3
@@ -912,39 +915,39 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ] ; then
-	for raster_outfile in `g.mlist rast pat="MskdModPOS*"` ; do
-		r.out.gdal input=$raster_outfile output=~/outfiles/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
+	for raster_outfile in `g.list raster pattern="MskdModPOS*"` ; do
+		r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw;predictor=3
 	done
 fi
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -264,8 +264,11 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -29,7 +29,7 @@
 #
 # COPYRIGHT:    (c) 2005-2019 CASAS Global (Center for the Analysis
 #                       of Sustainable Agricultural Systems Global
-#                       http://www.casasglobal.org/).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
@@ -157,7 +157,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -261,11 +261,13 @@
 
 # %flag
 # % key: p
-# % description: Produce bar chart plots summarizing raster statistics
+# % description: Produce barchart plots summarizing raster statistics
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -274,34 +276,35 @@ cleanup()
 {
 	# Remove temp directory.
 	\rm -rf $DIRTMP
-    # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	# Remove temp text files.
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+	\rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=medgold location=latlong_medgold
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
-    g.mapset mapset=medgold location=laea_colombia
-	g.mremove -f vect=voronoi*
-    g.mremove -f vect=selectedStates
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
-    g.mremove -f rast=selectedStatesRaster
+	g.mapset mapset=medgold location=laea_colombia
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=vector pattern="selectedStates"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
+	g.remove -f type=raster pattern="selectedStatesRaster"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -318,10 +321,10 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
-	exec g.parser "$0" "$@"
+    exec g.parser "$0" "$@"
 fi
 
 if test "$GISBASE" = ""; then
@@ -335,14 +338,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -421,13 +424,13 @@ if [ -n "$GIS_OPT_RESOLUTION" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR">~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR">${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl  "$HOME"
 
 # Run a perl script that gets rid of column names
-perl ~/PerlScripts/convertITA.pl "$HOME"
+perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -435,19 +438,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -475,7 +478,7 @@ g.mapset mapset=medgold location=laea_colombia
 # Selection of based on vector areas.
 if [ "$DEPARTMENTS" = 'all' ] ; then
 	# Full region for the Colombia mapping routine
-	g.region vect=colombia
+	g.region vector=colombia
 	v.to.rast input=colombia output=EtoSelectMask use=val value=1
 	# Make some room on the margins
 g.region n=n-70000 s=s-50000 e=e+50000 w=w+233000
@@ -483,10 +486,10 @@ g.region n=n-70000 s=s-50000 e=e+50000 w=w+233000
 	g.region -a res=1000
 else
     # Set region to an arbitrary subset of departments
-    echo $DEPARTMENTS>~/states.txt
-    perl ~/PerlScripts/cliparse_TC.pl "$HOME" 'iso_3166_2' 'string' "states.txt" "formulaStates.txt"
+    echo $DEPARTMENTS>${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_TC.pl "$HOME" 'iso_3166_2' 'string' "states.txt" "formulaStates.txt"
     v.extract input=colombia_departments output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=EtoSelectMask use=val value=1
@@ -498,12 +501,12 @@ fi
 
 # Use various tomato growing areas for masking model output
 if [ "$CROP" == "coffee" ]; then
-	r.mapcalc ElevMask = "if ((EtoSelectMask && coffee_HarvestedAreaFraction_colombia > $CROP_THRESHOLD), elevation_1KMmd_GMTEDmd_colombia, null())"
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc "ElevMask = if ((EtoSelectMask && coffee_HarvestedAreaFraction_colombia > $CROP_THRESHOLD), elevation_1KMmd_GMTEDmd_colombia, null())"
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use no mask for model output
 elif [ "$CROP" == "none" ]; then
-	r.mapcalc ElevMask = 'if (EtoSelectMask, elevation_1KMmd_GMTEDmd_colombia, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"	
+	r.mapcalc 'ElevMask = if (EtoSelectMask, elevation_1KMmd_GMTEDmd_colombia, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"	
 fi
 
 # Write header in the log file.
@@ -511,8 +514,8 @@ echo "This log reports names of input files used for analysis:" | tee -a "$SaveD
 
 # Retrieve range min and max values for possible use in legend drawing.
 # Maybe check if the files exists...
-min=`cat ~/min.txt`
-max=`cat ~/max.txt`
+min=`cat ${OUTFILES}/min.txt`
+max=`cat ${OUTFILES}/max.txt`
 
 # Set size of output image.
 cd $DIRTMP
@@ -530,7 +533,7 @@ for i in `ls`; do
 	# Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
     v.proj input=map$i location=latlong_medgold mapset=medgold\
-		output=map$i		
+		output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -563,31 +566,31 @@ for i in `ls`; do
     # Extract points lower than cutting point to map them with a different symbol.
     v.extract input=map$i output=mapZero$i \
         where="($varType < $CUT)"
-	
+
     # Extract points higher than upper cutting point to map them with a different symbol.
     v.extract input=map$i output=mapHigh$i \
         where="($varType > $HICUT)"
-	
+
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl  "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+	# Set mask for interpolation.
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -601,22 +604,22 @@ for i in `ls`; do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 	
 	
@@ -633,8 +636,8 @@ for i in `ls`; do
     d.erase color=white
 
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt
-	g.mremove -f vect=voronoi*
+	\rm -f ${OUTFILES}/voronoi*.txt
+	g.remove -f type=vector pattern="voronoi*"
 
 	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -645,29 +648,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -683,29 +686,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -745,13 +748,13 @@ for i in `ls`; do
     # d.barscale -l at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
-    echo "$LEG1" > ~/legend1.txt;
-    Legend1="`cat ~/legend1.txt`";
-    Year="`cat ~/year$mapcycle.txt`";
-    echo $Legend1 $Year "($CROP)" > ~/legend1$mapcycle.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt;
+    Legend1="`cat ${OUTFILES}/legend1.txt`";
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`";
+    echo $Legend1 $Year "($CROP)" > ${OUTFILES}/legend1$mapcycle.txt
 
     # Text for legend (at= percentage, [0,0] is lower left).
-	d.text size=3 color=black at=5,94 < ~/legend1$mapcycle.txt
+	d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
 	d.mon stop=PNG
@@ -806,8 +809,8 @@ for i in `ls`; do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -863,7 +866,7 @@ else
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
     d.erase color=white
-    r.mapcalc selectedStates.composite = 'if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_colombia, null())'
+    r.mapcalc 'selectedStates.composite = if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_colombia, null())'
     r.colors map=selectedStates.composite raster=NE1_HR_LC_SR_W_DR.composite_colombia
     d.his i=SR_HR_colombia_clip h=selectedStates.composite brighten=5
     d.vect map=ne_10m_coastline_colombia type=boundary color=150:150:150 width=3
@@ -893,33 +896,33 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 
 # Set default browser for HTML visual summary.

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -274,8 +274,11 @@
 # % description: Produce barchart plots summarizing raster statistics
 # %end
 
-# Config to set environmental variables
-source "config.cfg"
+# Set some environmental variables
+PERLSCRIPTS="${HOME}/PerlScripts"
+OUTFILES="${HOME}/outfiles"
+PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+FONTDIR="C:\Windows\Fonts\\"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -29,13 +29,13 @@
 #
 # COPYRIGHT:    (c) 2005-2020 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
-#                       http://www.casasglobal.org/).
+#                       https://www.casasglobal.org/).
 #
 #		This program is free software under the GNU General Public
 #		License (>=v2). Read the file COPYING that comes with GRASS
 #		for details.
 #
-############################################################################
+#############################################################################
 
 # %Module
 # %  description: Map the output of CASAS models for the conterminous United States, Mexico, and Central America
@@ -157,7 +157,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram-equalized color rule
+# % description: Use histogram equalized color rule
 # %end
 
 # %flag
@@ -271,11 +271,13 @@
 
 # %flag
 # % key: p
-# % description: Produce bar chart plots summarizing raster statistics
+# % description: Produce barchart plots summarizing raster statistics
 # %end
 
+# Config to set environmental variables
+source "config.cfg"
+
 # Directory with temporary files (see convert.pl script).
-DIRTMP="$HOME/models_temp"
 
 # export GRASS_VERBOSE=1
 
@@ -284,38 +286,39 @@ cleanup()
 {
 	# Remove temp directory.
 	\rm -rf $DIRTMP
-    # Remove temp text files.
-	\rm -f ~/clipRegion.txt
-	\rm -f ~/formula*.txt
-	\rm -f ~/voronoi.txt
-	\rm -f ~/legend*.txt;
-	\rm -f ~/year*.txt;
-	\rm -f ~/inputPar.txt;
-	\rm -f ~/weather.txt;
-	\rm -f ~/customColorRule.txt;
-	\rm -f ~/min.txt;
-	\rm -f ~/max.txt;
-    \rm -f ~/states.txt
+	# Remove temp text files.
+	\rm -f ${OUTFILES}/clipRegion.txt
+	\rm -f ${OUTFILES}/formula*.txt
+	\rm -f ${OUTFILES}/voronoi.txt
+	\rm -f ${OUTFILES}/legend*.txt;
+	\rm -f ${OUTFILES}/year*.txt;
+	\rm -f ${OUTFILES}/inputPar.txt;
+	\rm -f ${OUTFILES}/weather.txt;
+	\rm -f ${PALETTES}/customColorRule.txt;
+	\rm -f ${OUTFILES}/min.txt;
+	\rm -f ${OUTFILES}/max.txt;
+	\rm -f ${OUTFILES}/states.txt
 	# Remove gis temp files in latlong location
 	g.mapset mapset=luigi location=latlong
-	g.mremove -f vect=map*
+	g.remove -f type=vector pattern="map*"
 	# Remove gis temp files in mapping location
 	if [ "$GIS_OPT_STATES" = 'HI' ] ; then
-        g.mapset mapset=luigi location=AEA_Hawaii
-    else
-        g.mapset mapset=luigi location=AEA_US_mex_central_america
-    fi
-	g.mremove -f vect=voronoi*
-    g.mremove -f vect=selectedStates
-	g.mremove -f rast=model* vect=map*
-	g.mremove -f rast=model*
-	g.mremove -f rast=Mskd*
-	g.mremove -f rast=interpol*
-    g.mremove -f rast=selectedStatesRaster
+        	g.mapset mapset=luigi location=AEA_Hawaii
+   	else
+  	      g.mapset mapset=luigi location=AEA_US_mex_central_america
+  	fi
+	g.remove -f type=vector pattern="voronoi*"
+	g.remove -f type=vector pattern="selectedStates"
+	g.remove -f type=raster,vector pattern="map*"
+	g.remove -f type=raster pattern="model*"
+	g.remove -f type=raster pattern="Mskd*"
+	g.remove -f type=raster pattern="interpol*"
+	g.remove -f type=raster pattern="selectedStatesRaster"
 	# Remove old masks.
-	g.mremove -f rast=Elev* vect=Eto*
-	g.mremove -f rast=Eto*
-	g.mremove -f rast=MASK*
+	g.remove -f type=vector pattern="Eto*"
+	g.remove -f type=raster pattern="Elev*"
+	g.remove -f type=raster pattern="Eto*"
+	g.remove -f type=raster pattern="MASK*"
 }
 
 # In case of user break:
@@ -332,10 +335,10 @@ exitprocedure()
 trap 'exitprocedure' 1 2 3 9 15 SIGINT SIGABRT SIGILL SIGTERM
 
 # Print column names of model output files.
-perl ~/PerlScripts/printCols.pl "$HOME" > ~/varList.txt
+perl ${PERLSCRIPTS}/printCols.pl "$HOME" > ${OUTFILES}/varList.txt
 
 if [ "$1" != "@ARGS_PARSED@" ] ; then
-	exec g.parser "$0" "$@"
+    exec g.parser "$0" "$@"
 fi
 
 if test "$GISBASE" = ""; then
@@ -349,14 +352,14 @@ cleanup
 # Set user-defined directory where to save
 # output maps.
 if [ -n "$GIS_OPT_SAVEDIR" ] ; then
-    if [ -d "$HOME/outfiles/$GIS_OPT_SAVEDIR" ] ; then
+    if [ -d "${OUTFILES}/$GIS_OPT_SAVEDIR" ] ; then
 		echo ""
 		echo "The directory \"$GIS_OPT_SAVEDIR\" already exists."
 		echo "Please, choose a different name."
 		echo ""
 		exit 1
 	else
-		SaveDir="$HOME/outfiles/$GIS_OPT_SAVEDIR"
+		SaveDir="${OUTFILES}/$GIS_OPT_SAVEDIR"
 		mkdir -p "$SaveDir";
 	fi
 fi
@@ -435,14 +438,14 @@ if [ -n "$GIS_OPT_UPBARCOL" ] ; then
 fi
 
 # Write LON, LAT, and PAR to a text file as input for the perl script
-echo "$LON $LAT $PAR $YEAR">~/inputPar.txt
+echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 
 # Print years to text files for use in legend.
-perl ~/PerlScripts/printYear.pl  "$HOME"
+perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
 #  (not supported in GRASS 6.0)
-perl ~/PerlScripts/convert.pl "$HOME"
+perl ${PERLSCRIPTS}/convert.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
 if [ "$GIS_FLAG_X" -eq 1 ] ; then
@@ -450,19 +453,19 @@ if [ "$GIS_FLAG_X" -eq 1 ] ; then
 	if [ "$GIS_FLAG_D" -eq 1 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "$HICUT" "divYes"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_DIV" "$CUT" "na" "divYes"
 		fi
 	# Same range for all maps with regular color scheme.
 	elif [ "$GIS_FLAG_D" -eq 0 ] ; then
 		# Check if there is an upper cutting point set.
 		if [ "$GIS_FLAG_U" -eq 1 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "$HICUT" "divNo"
 		# Otherwise just use the lower cutting point.
 		elif [ "$GIS_FLAG_U" -eq 0 ] ; then
-			perl ~/PerlScripts/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
+			perl ${PERLSCRIPTS}/multiColorRule.pl "$HOME" "$RULE_REG" "$CUT" "na" "divNo"
 		fi
 	fi
 fi
@@ -496,10 +499,10 @@ if [ "$STATES" = 'US_conterminous' ] ; then
     STATES='AL AZ AR CA CO CT DC DE FL GA ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY'
     g.region res=3000
     # Set region to an arbitrary subset of US states.
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
     v.extract input=us_conterm_hawaii_mex_centr_am output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=selectedStatesRaster use=val value=1
@@ -511,10 +514,10 @@ elif [ "$STATES" = 'US_conterm_Mex' ] ; then
     STATES='MX AL AZ AR CA CO CT DC DE FL GA ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY'
     g.region res=3000
     # Set region to an arbitrary subset of US states
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
     v.extract input=us_conterm_hawaii_mex_centr_am output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=selectedStatesRaster use=val value=1
@@ -526,10 +529,10 @@ elif [ "$STATES" = 'US_Mex_CentralAmerica' ] ; then
     STATES='MX AL AZ AR CA CO CT DC DE FL GA ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY BZ GT HN SV NI CR PN'
     g.region res=3000
     # Set region to an arbitrary subset of US states
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
     v.extract input=us_conterm_hawaii_mex_centr_am output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=selectedStatesRaster use=val value=1
@@ -540,10 +543,10 @@ elif [ "$STATES" = 'US_Mex_CentralAmerica' ] ; then
 elif [ "$STATES" = 'HI' ] ; then
     g.region res=1000
     # Set region to an arbitrary subset of US states
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
     v.extract input=us_conterm_hawaii_mex_centr_am output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=selectedStatesRaster use=val value=1
@@ -552,10 +555,10 @@ elif [ "$STATES" = 'HI' ] ; then
 else
     g.region res=3000
     # Set region to an arbitrary subset of US states
-    echo $STATES>~/states.txt
-    perl ~/PerlScripts/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
+    echo $STATES > ${OUTFILES}/states.txt
+    perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "STATE_CODE" "states.txt" "formulaStates.txt"
     v.extract input=us_conterm_hawaii_mex_centr_am output=selectedStates\
-        where="`cat ~/formulaStates.txt`"
+        where="`cat ${OUTFILES}/formulaStates.txt`"
     # Define the extent of the map and its grid resolution (currently 1 km).
     g.region -a vect=selectedStates
     v.to.rast input=selectedStates output=selectedStatesRaster use=val value=1
@@ -567,42 +570,42 @@ fi
 
 #~ # Build a mask to select the region of interst to the study
 #~ # based on Italian admnistrative regions (ISTAT codes).
-#~ echo $ECOREG>~/clipRegion.txt;
-#~ perl ~/PerlScripts/cliparse_US.pl "$HOME" "ECO" "clipRegion.txt" "formula.txt"
+#~ echo $ECOREG>${OUTFILES}/clipRegion.txt;
+#~ perl ${PERLSCRIPTS}/cliparse_US.pl "$HOME" "ECO" "clipRegion.txt" "formula.txt"
 #~ v.extract input=useco_3_areas output=EtoSelect\
-    #~ where="`cat ~/formula.txt`";
+    #~ where="`cat ${OUTFILES}/formula.txt`";
 #~ v.to.rast input=EtoSelect output=EtoSelectMask use=val value=1;
-#~ rm ~/clipRegion.txt;
-#~ rm ~/formula.txt;
+#~ rm ${OUTFILES}/clipRegion.txt;
+#~ rm ${OUTFILES}/formula.txt;
 
 # Shortcut to bypass commented text above.
-g.copy rast=selectedStatesRaster,EtoSelectMask
+g.copy raster=selectedStatesRaster,EtoSelectMask
 
 # Use various tomato growing areas for masking model output
 if [ "$CROP" == "tomato_harvested" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), US_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_YieldPerHectare_175_above_0_mask), US_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_temperate" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), US_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_temperate), US_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_tropical" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), US_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_tropical), US_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_combined" ]; then
-	r.mapcalc ElevMask = 'if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), US_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"
+	r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), US_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Use no mask for model output
 elif [ "$CROP" == "none" ]; then
-	r.mapcalc ElevMask = 'if (EtoSelectMask, US_dem, null())'
-	r.mapcalc ElevAltMask = "if (ElevMask < $ALT, ElevMask, null())"	
+	r.mapcalc 'ElevMask = if (EtoSelectMask, US_dem, null())'
+	r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"	
 fi
 
 # Write header in the log file.
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing. Maybe check if the files exists...
-min=`cat ~/min.txt`
-max=`cat ~/max.txt`
+min=`cat ${OUTFILES}/min.txt`
+max=`cat ${OUTFILES}/max.txt`
 
 # Set size of output image.
 cd $DIRTMP
@@ -620,7 +623,7 @@ for i in `ls`; do
 	# Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
     v.proj input=map$i location=latlong mapset=luigi\
-		output=map$i;		
+		output=map$i;
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -653,31 +656,31 @@ for i in `ls`; do
     # Extract points lower than cutting point to map them with a different symbol.
     v.extract input=map$i output=mapZero$i \
         where="($varType < $CUT)"
-	
+
     # Extract points higher than upper cutting point to map them with a different symbol.
     v.extract input=map$i output=mapHigh$i \
         where="($varType > $HICUT)"
-	
+
 	# Obtain Voronoi polygons from points to mask values
 	#  above/below cutting points and select the right polygons.
 	v.voronoi input=map$i output=voronoi
-	v.category option=print input=mapZero$i > ~/voronoi.txt
+	v.category option=print input=mapZero$i > ${OUTFILES}/voronoi.txt
 	# Check if high values are to be masked.
 	if [ "$GIS_FLAG_U" -eq 1 ] ; then
-		v.category option=print input=mapHigh$i >> ~/voronoi.txt
+		v.category option=print input=mapHigh$i >> ${OUTFILES}/voronoi.txt
 	fi
-	perl ~/PerlScripts/voroparse.pl  "$HOME"
+	perl ${PERLSCRIPTS}/voroparse.pl  "$HOME"
 	#~ v.extract input=voronoi output=voronoiSel\
-        #~ where="`cat ~/voronoiFormula.txt`"
+        #~ where="`cat ${OUTFILES}/voronoiFormula.txt`"
     # Version without DB query.
 	v.extract input=voronoi output=voronoiSel\
-        file=~/voronoi.txt
+        file=${OUTFILES}/voronoi.txt
 		
 	# Transform selected Voronoi polygons to raster for masking.
 	v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
 
-    # Set mask for interpolation.
-    g.copy rast=ElevAltMask,MASK
+	# Set mask for interpolation.
+	g.copy raster=ElevAltMask,MASK
 	
 	if [ $SURF == "idw" ] ; then
         # Interpolate the reprojected vector after proper masking by
@@ -691,22 +694,22 @@ for i in `ls`; do
 		# Constrain interpolated raster within max-min from vector input
 		# and make values >max or <min equal to max or min.
 		eval `v.univar -g -e map=mapPos$i type=point column=$varType`
-		r.mapcalc interpolMin$i = "if(interpolRaw$i >= $min, interpolRaw$i, $min)"
-		r.mapcalc interpolMinMax$i = "if(interpolMin$i <= $max, interpolMin$i, $max)"
+		r.mapcalc "interpolMin$i = if(interpolRaw$i >= $min, interpolRaw$i, $min)"
+		r.mapcalc "interpolMinMax$i = if(interpolMin$i <= $max, interpolMin$i, $max)"
 		
 		# Clip for altitude
-		r.mapcalc interpol$i = "if(ElevAltMask, interpolMinMax$i, null())"
+		r.mapcalc "interpol$i = if(ElevAltMask, interpolMinMax$i, null())"
     fi
 
 	# Remove MASK that would otherwise prevent full map display.
-	g.remove rast=MASK
+	g.remove -f type=raster name=MASK
 
     # Remove stuff outside cutting points from interpolated raster.
-    if [ -n "`cat ~/voronoi.txt`" ]; then
-		r.mapcalc MskdBufRev$i = "if(isnull(MskdBuffer$i), 1, null())"
-		r.mapcalc MskdModPOS$i = "if(MskdBufRev$i, interpol$i, null())"
+    if [ -n "`cat ${OUTFILES}/voronoi.txt`" ]; then
+		r.mapcalc "MskdBufRev$i = if(isnull(MskdBuffer$i), 1, null())"
+		r.mapcalc "MskdModPOS$i = if(MskdBufRev$i, interpol$i, null())"
     else
-    	g.copy rast=interpol$i,MskdModPOS$i
+    	g.copy raster=interpol$i,MskdModPOS$i
     fi
 
     # Set png file for output.
@@ -715,8 +718,8 @@ for i in `ls`; do
     d.erase color=white
 
     # Remove voronoi-related stuff.
-	\rm -f ~/voronoi*.txt
-	g.mremove -f vect=voronoi*
+	\rm -f ${OUTFILES}/voronoi*.txt
+	g.remove -f type=vector pattern="voronoi*"
 
 	# If flag -g is checked, output is a greyscale figure
 	if [ "$GIS_FLAG_G" -eq 1 ] ; then
@@ -727,29 +730,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/greyColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/greyColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi
@@ -786,29 +789,29 @@ for i in `ls`; do
 		if [ "$GIS_FLAG_X" -eq 1 ] || [ "$GIS_FLAG_D" -eq 1 ] ; then
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/customColorRule.txt | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		else
             if [ "$GIS_FLAG_E" -eq 1 ] ; then
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -e map=MskdModPOS$i color=rules
                 fi
             else
                 if  [ "$GIS_FLAG_L" -eq 1 ] ; then
-                    cat ~/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors -g map=MskdModPOS$i color=rules
                 else
-                    cat ~/defaultColorRule | r.colors map=MskdModPOS$i color=rules
+                    cat ${PALETTES}/defaultColorRule | r.colors map=MskdModPOS$i color=rules
                 fi
             fi
 		fi		
@@ -820,6 +823,7 @@ for i in `ls`; do
         # (this is supposed to make the shaded relief a bit less fuzzy -- step 3 NOT implemented here)
         # r.shaded.releif 60/315/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
+        # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
 		# Drape model raster over a shaded relief and add state
 		# boundaries, lakes, weather stations, etc.
@@ -893,19 +897,19 @@ for i in `ls`; do
     # d.barscbarscale -l at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
-    echo "$LEG1" > ~/legend1.txt;
-    Legend1="`cat ~/legend1.txt`";
-    Year="`cat ~/year$mapcycle.txt`";
-    echo $Legend1 $Year "($CROP)" > ~/legend1$mapcycle.txt
+    echo "$LEG1" > ${OUTFILES}/legend1.txt;
+    Legend1="`cat ${OUTFILES}/legend1.txt`";
+    Year="`cat ${OUTFILES}/year$mapcycle.txt`";
+    echo $Legend1 $Year "($CROP)" > ${OUTFILES}/legend1$mapcycle.txt
 
     # Text for legend (at= percentage, [0,0] is lower left).
-	d.text size=3 color=black at=5,94 < ~/legend1$mapcycle.txt
+	d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
 	d.mon stop=PNG
 	
 	# Write a log with names of input files.
-	echo "$i" | tee -a "$SaveDir"/"$LEG1".log
+	echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
 
     ###############
@@ -961,8 +965,8 @@ for i in `ls`; do
 	# If flag -p is checked, then write .rep report files to be plotted.
 	if [ "$GIS_FLAG_P" -eq 1 ] ; then
 		# Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
-		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.tot
-		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4>"$SaveDir"/$i.rep
+		#~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
+		#~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
         d.erase color=white
@@ -1024,7 +1028,7 @@ else
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
     d.erase color=white
-    r.mapcalc selectedStates.composite = 'if(selectedStatesRaster, natural_earth_color.composite, null())'
+    r.mapcalc 'selectedStates.composite = if(selectedStatesRaster, natural_earth_color.composite, null())'
     r.colors map=selectedStates.composite raster=natural_earth_color.composite
     d.his i=MSR_50M_land h=selectedStates.composite
     d.vect map=world_bounds type=boundary color=150:150:150 width=2
@@ -1062,36 +1066,36 @@ else
 fi
 
 # Write html pages.
-perl ~/PerlScripts/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
+perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots";
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ] ; then
-	#~ perl ~/PerlScripts/makePlotData.pl "$SaveDir"
-	#~ perl ~/PerlScripts/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
-	#~ perl ~/PerlScripts/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
-	perl ~/PerlScripts/HtmlPlotC.pl "$SaveDir" "${LEG1}";
+	#~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
+	#~ perl ${PERLSCRIPTS}/HtmlPlotA_ita.pl "$SaveDir" "$LEG1 $LEG2";
+	#~ perl ${PERLSCRIPTS}/HtmlPlotB.pl "$SaveDir" "$LEG1 $LEG2";
+	perl ${PERLSCRIPTS}/HtmlPlotC.pl "$SaveDir" "${LEG1}";
 fi
 
 # One may want to save palette used for analysis.
 if [ "$GIS_FLAG_G" -eq 1 ] ; then
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/greyColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/greyColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 else
     if [ "$GIS_FLAG_X" -eq 1 ] ; then
-        cp ~/customColorRule.txt ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/customColorRule.txt ${OUTFILES}/$GIS_OPT_SAVEDIR
     else
-        cp ~/defaultColorRule ~/outfiles/$GIS_OPT_SAVEDIR
+        cp ${PALETTES}/defaultColorRule ${OUTFILES}/$GIS_OPT_SAVEDIR
     fi
 fi
 
 # How about saving also data used for analysis?
-mkdir -p ~/outfiles/$GIS_OPT_SAVEDIR/data/
-cp ~/outfiles/*.txt ~/outfiles/$GIS_OPT_SAVEDIR/data/
+mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
+cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
 
-# Set defualt browser for HTML visual summary.
+# Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"


### PR DESCRIPTION
Code style:
- changed `~/` path to environmental variable, configurable on top of the script after the parser section
  - `${OUTPUT}` variable
  - `${PALETTES}` variable
  - `${PERLSCRIPTS}` variable

GRASS GIS 8 updates (from GRASS GIS 6):
- update of `g.mremove` -> `g.remove`
- update of `g.mlist` -> `g.list`
- update of `g.copy` -> `g.copy`
- update of `r.mapcalc` expressions (fix initial quote position)

Minor:
- cleanup of spurious white spaces
- few URL fixes

Note: for comparison and some script streamlining I have used `meld <scriptA> <scriptB>` to compare all-to-all linewise. There are still difference which might be discussed how to handle them.