### PR TITLE
License declaration using SPDX entry

### DIFF
--- a/casas_gis/cleanup.py
+++ b/casas_gis/cleanup.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 # Clenaup routine?
 # See https://grasswiki.osgeo.org/wiki/Converting_Bash_scripts_to_Python
 

--- a/casas_gis/cleanup.py
+++ b/casas_gis/cleanup.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/color.py
+++ b/casas_gis/color.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 """ Color related stuff.
     Select color scheme, adjust to data, etc."""
 

--- a/casas_gis/color.py
+++ b/casas_gis/color.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/constants.py
+++ b/casas_gis/constants.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 import pathlib
 import locations as loc
 

--- a/casas_gis/constants.py
+++ b/casas_gis/constants.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/gis_init.py
+++ b/casas_gis/gis_init.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 import pathlib
 
 # define GRASS DATABASE

--- a/casas_gis/gis_init.py
+++ b/casas_gis/gis_init.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/grass.py
+++ b/casas_gis/grass.py
@@ -7,7 +7,7 @@
 # a set of bash shell scripts originally developed by Luigi Ponti starting
 # in 2005 at University of California, Berkeley.
 #
-# Copyright (c) 2005-2022 Luigi Ponti and CASAS Global
+# Copyright (c) 2005-2022 Luigi Ponti quartese gmail.com and CASAS Global
 # (Center for the Analysis of Sustainable Agricultural Systems Global
 # http://www.casasglobal.org/).
 #

--- a/casas_gis/grass.py
+++ b/casas_gis/grass.py
@@ -11,18 +11,7 @@
 # (Center for the Analysis of Sustainable Agricultural Systems Global
 # http://www.casasglobal.org/).
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 #######
 

--- a/casas_gis/gui.py
+++ b/casas_gis/gui.py
@@ -1,3 +1,18 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
+
 # %Module
 # %  description: CASAS GIS
 # %End

--- a/casas_gis/gui.py
+++ b/casas_gis/gui.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/input.py
+++ b/casas_gis/input.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 """ Read a tab-separated CSV text file into a pandas dataframe, return
     (numbered) column names, number of rows, and the dictionary itself."""
 

--- a/casas_gis/input.py
+++ b/casas_gis/input.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/interpolation.py
+++ b/casas_gis/interpolation.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 """ Library of funcitonality reeated to interpolation. """
 
 import pandas as pd

--- a/casas_gis/interpolation.py
+++ b/casas_gis/interpolation.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/locations.py
+++ b/casas_gis/locations.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 import gis_init as ini
 
 andalusia = {

--- a/casas_gis/locations.py
+++ b/casas_gis/locations.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/report.py
+++ b/casas_gis/report.py
@@ -1,2 +1,16 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 """ Get an HTML report where results of the mapping and analysis are reported,
     see e.g., https://jackbakerds.com/posts/python-equivalent-rmarkdown/ """

--- a/casas_gis/report.py
+++ b/casas_gis/report.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis/stats.py
+++ b/casas_gis/stats.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 """ Compute needed stats, generate plots, etc.
     pandas will come in handy.
     Marginal analysis?

--- a/casas_gis/stats.py
+++ b/casas_gis/stats.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/casas_gis_old/PerlScripts/HtmlPlotA.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA.pl
@@ -2,7 +2,8 @@
 # Script that plots raster statistics by ecozones
 # using gnuplot and puts .png outputs in a HTML page
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotA.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that plots raster statistics by ecozones
 # using gnuplot and puts .png outputs in a HTML page
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 
 # Read Directory where maps are saved and

--- a/casas_gis_old/PerlScripts/HtmlPlotA.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA.pl
@@ -3,7 +3,7 @@
 # using gnuplot and puts .png outputs in a HTML page
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
@@ -2,7 +2,8 @@
 # Script that plots raster statistics by ecozones
 # using gnuplot and puts .png outputs in a HTML page
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that plots raster statistics by ecozones
 # using gnuplot and puts .png outputs in a HTML page
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 
 # Read Directory where maps are saved and

--- a/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotA_ita.pl
@@ -3,7 +3,7 @@
 # using gnuplot and puts .png outputs in a HTML page
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 19 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotB.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotB.pl
@@ -3,7 +3,7 @@
 # using gnuplot and puts .png outputs in a HTML page
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotB.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotB.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that plots overall raster statistics
 # using gnuplot and puts .png outputs in a HTML page
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 September 2006
 
 # Read Directory where maps are saved and

--- a/casas_gis_old/PerlScripts/HtmlPlotB.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotB.pl
@@ -2,7 +2,8 @@
 # Script that plots overall raster statistics
 # using gnuplot and puts .png outputs in a HTML page
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 September 2006
 

--- a/casas_gis_old/PerlScripts/HtmlPlotC.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotC.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that plots histograms produced by
 # d.histogram and puts .png outputs in a HTML page
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 January 2008
 
 # Read Directory where maps are saved and

--- a/casas_gis_old/PerlScripts/HtmlPlotC.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotC.pl
@@ -2,7 +2,8 @@
 # Script that plots histograms produced by
 # d.histogram and puts .png outputs in a HTML page
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 January 2008
 

--- a/casas_gis_old/PerlScripts/HtmlPlotC.pl
+++ b/casas_gis_old/PerlScripts/HtmlPlotC.pl
@@ -3,7 +3,7 @@
 # d.histogram and puts .png outputs in a HTML page
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 January 2008
 

--- a/casas_gis_old/PerlScripts/SubtractOutput.pl
+++ b/casas_gis_old/PerlScripts/SubtractOutput.pl
@@ -5,6 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 
 # Syntax:

--- a/casas_gis_old/PerlScripts/SubtractOutput.pl
+++ b/casas_gis_old/PerlScripts/SubtractOutput.pl
@@ -5,7 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/PerlScripts/SubtractOutput.pl
+++ b/casas_gis_old/PerlScripts/SubtractOutput.pl
@@ -4,7 +4,8 @@
 # in CASAS model outputs. NOTE: the script is supposed
 # to use files with the same number of rows & columns.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/PerlScripts/cliparse.pl
+++ b/casas_gis_old/PerlScripts/cliparse.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that transform a string containing ET0 regions
 # to a formula suitable for use in GRASS clipping
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/cliparse.pl
+++ b/casas_gis_old/PerlScripts/cliparse.pl
@@ -2,7 +2,8 @@
 # Script that transform a string containing ET0 regions
 # to a formula suitable for use in GRASS clipping
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 

--- a/casas_gis_old/PerlScripts/cliparse.pl
+++ b/casas_gis_old/PerlScripts/cliparse.pl
@@ -3,7 +3,7 @@
 # to a formula suitable for use in GRASS clipping
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 

--- a/casas_gis_old/PerlScripts/cliparseITA.pl
+++ b/casas_gis_old/PerlScripts/cliparseITA.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that transform a string containing ET0 regions
 # to a formula suitable for use in GRASS clipping
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/cliparseITA.pl
+++ b/casas_gis_old/PerlScripts/cliparseITA.pl
@@ -2,7 +2,8 @@
 # Script that transform a string containing ET0 regions
 # to a formula suitable for use in GRASS clipping
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 

--- a/casas_gis_old/PerlScripts/cliparseITA.pl
+++ b/casas_gis_old/PerlScripts/cliparseITA.pl
@@ -3,7 +3,7 @@
 # to a formula suitable for use in GRASS clipping
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 January 2006
 

--- a/casas_gis_old/PerlScripts/cliparse_TC.pl
+++ b/casas_gis_old/PerlScripts/cliparse_TC.pl
@@ -7,6 +7,7 @@
 # if quoting is necessary. Number or string.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 
 use strict;

--- a/casas_gis_old/PerlScripts/cliparse_TC.pl
+++ b/casas_gis_old/PerlScripts/cliparse_TC.pl
@@ -7,7 +7,7 @@
 # if quoting is necessary. Number or string.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 

--- a/casas_gis_old/PerlScripts/cliparse_TC.pl
+++ b/casas_gis_old/PerlScripts/cliparse_TC.pl
@@ -6,7 +6,8 @@
 # _TC means type check--it checks type of column to know
 # if quoting is necessary. Number or string.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 

--- a/casas_gis_old/PerlScripts/cliparse_US.pl
+++ b/casas_gis_old/PerlScripts/cliparse_US.pl
@@ -5,7 +5,7 @@
 # column name, and input and output files can be specified.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 

--- a/casas_gis_old/PerlScripts/cliparse_US.pl
+++ b/casas_gis_old/PerlScripts/cliparse_US.pl
@@ -4,7 +4,8 @@
 # This version takes more arguments so that also attribute
 # column name, and input and output files can be specified.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 

--- a/casas_gis_old/PerlScripts/cliparse_US.pl
+++ b/casas_gis_old/PerlScripts/cliparse_US.pl
@@ -5,6 +5,7 @@
 # column name, and input and output files can be specified.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 26 January 2010
 
 use strict;

--- a/casas_gis_old/PerlScripts/convert.pl
+++ b/casas_gis_old/PerlScripts/convert.pl
@@ -5,7 +5,7 @@
 # This version accept outfiles names such as as "Olive_02Mar06_00003.txt".
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 February 2006
 

--- a/casas_gis_old/PerlScripts/convert.pl
+++ b/casas_gis_old/PerlScripts/convert.pl
@@ -4,7 +4,8 @@
 
 # This version accept outfiles names such as as "Olive_02Mar06_00003.txt".
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 February 2006
 

--- a/casas_gis_old/PerlScripts/convert.pl
+++ b/casas_gis_old/PerlScripts/convert.pl
@@ -5,6 +5,7 @@
 # This version accept outfiles names such as as "Olive_02Mar06_00003.txt".
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 February 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/convertITA.pl
+++ b/casas_gis_old/PerlScripts/convertITA.pl
@@ -4,7 +4,8 @@
 
 # This version accept outfiles names such as as "Olive-02Mar06-00003.txt".
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 13 April 2006
 

--- a/casas_gis_old/PerlScripts/convertITA.pl
+++ b/casas_gis_old/PerlScripts/convertITA.pl
@@ -5,6 +5,7 @@
 # This version accept outfiles names such as as "Olive-02Mar06-00003.txt".
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 13 April 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/convertITA.pl
+++ b/casas_gis_old/PerlScripts/convertITA.pl
@@ -5,7 +5,7 @@
 # This version accept outfiles names such as as "Olive-02Mar06-00003.txt".
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 13 April 2006
 

--- a/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
+++ b/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
@@ -7,7 +7,7 @@
 # getBoxplotColorRule.pl whiskerLow whiskerHigh absMin absMax zeroCentered(divNo|divYes) rasterMapName
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 October 2013
 

--- a/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
+++ b/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
@@ -6,7 +6,8 @@
 # The central color may be placed at an arbitrary value ($scaleCenter).
 # getBoxplotColorRule.pl whiskerLow whiskerHigh absMin absMax zeroCentered(divNo|divYes) rasterMapName
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 October 2013
 

--- a/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
+++ b/casas_gis_old/PerlScripts/getBoxplotColorRule.pl
@@ -3,12 +3,11 @@
 # of colors and the range of data.
 
 # Can use any combination of colors.
-
 # The central color may be placed at an arbitrary value ($scaleCenter).
-
 # getBoxplotColorRule.pl whiskerLow whiskerHigh absMin absMax zeroCentered(divNo|divYes) rasterMapName
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 October 2013
 
 use strict;

--- a/casas_gis_old/PerlScripts/htmlSum.pl
+++ b/casas_gis_old/PerlScripts/htmlSum.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 # Script that writes a HTML visual summary for CASAS models
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 April 2006
 

--- a/casas_gis_old/PerlScripts/htmlSum.pl
+++ b/casas_gis_old/PerlScripts/htmlSum.pl
@@ -2,7 +2,7 @@
 # Script that writes a HTML visual summary for CASAS models
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 April 2006
 

--- a/casas_gis_old/PerlScripts/htmlSum.pl
+++ b/casas_gis_old/PerlScripts/htmlSum.pl
@@ -1,6 +1,8 @@
 #!/usr/bin/perl -w
 # Script that writes a HTML visual summary for CASAS models
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 16 April 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/makePlotData.pl
+++ b/casas_gis_old/PerlScripts/makePlotData.pl
@@ -3,6 +3,7 @@
 # puts it in a form suitable to produce a plot.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 15 September 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/makePlotData.pl
+++ b/casas_gis_old/PerlScripts/makePlotData.pl
@@ -3,7 +3,7 @@
 # puts it in a form suitable to produce a plot.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 15 September 2006
 

--- a/casas_gis_old/PerlScripts/makePlotData.pl
+++ b/casas_gis_old/PerlScripts/makePlotData.pl
@@ -2,7 +2,8 @@
 # Script that takes the output of r.stats and
 # puts it in a form suitable to produce a plot.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 15 September 2006
 

--- a/casas_gis_old/PerlScripts/multiColorRule.pl
+++ b/casas_gis_old/PerlScripts/multiColorRule.pl
@@ -8,6 +8,7 @@
 # The central color will get a zero value.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 24 April 2008
 
 use strict;

--- a/casas_gis_old/PerlScripts/multiColorRule.pl
+++ b/casas_gis_old/PerlScripts/multiColorRule.pl
@@ -8,7 +8,7 @@
 # The central color will get a zero value.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 24 April 2008
 

--- a/casas_gis_old/PerlScripts/multiColorRule.pl
+++ b/casas_gis_old/PerlScripts/multiColorRule.pl
@@ -7,7 +7,8 @@
 
 # The central color will get a zero value.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 24 April 2008
 

--- a/casas_gis_old/PerlScripts/printCols.pl
+++ b/casas_gis_old/PerlScripts/printCols.pl
@@ -5,7 +5,7 @@
 # transferred to a printYear.pl script (NOTE).
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 

--- a/casas_gis_old/PerlScripts/printCols.pl
+++ b/casas_gis_old/PerlScripts/printCols.pl
@@ -4,7 +4,8 @@
 # The part that prints years for legend has been
 # transferred to a printYear.pl script (NOTE).
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 

--- a/casas_gis_old/PerlScripts/printCols.pl
+++ b/casas_gis_old/PerlScripts/printCols.pl
@@ -3,7 +3,9 @@
 # for proper input selection in the GRASS parser.
 # The part that prints years for legend has been
 # transferred to a printYear.pl script (NOTE).
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/printYear.pl
+++ b/casas_gis_old/PerlScripts/printYear.pl
@@ -2,7 +2,8 @@
 # Script that prints analysis years to a file according to
 # GRASS parser input for use in legend.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 

--- a/casas_gis_old/PerlScripts/printYear.pl
+++ b/casas_gis_old/PerlScripts/printYear.pl
@@ -3,7 +3,7 @@
 # GRASS parser input for use in legend.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 

--- a/casas_gis_old/PerlScripts/printYear.pl
+++ b/casas_gis_old/PerlScripts/printYear.pl
@@ -1,7 +1,9 @@
 #!/usr/bin/perl -w
 # Script that prints analysis years to a file according to
 # GRASS parser input for use in legend.
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 2 March 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/subtract.pl
+++ b/casas_gis_old/PerlScripts/subtract.pl
@@ -12,7 +12,7 @@ use strict;
 # NOTE:
 #           
 #
-# COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
+# Copyright:    (c) 2008 Luigi Ponti, quartese at gmail.com
 #                   CASAS (Center for the Analysis of Sustainable
 #                   Agricultural Systems, https://www.casasglobal.org/)
 #

--- a/casas_gis_old/PerlScripts/subtract.pl
+++ b/casas_gis_old/PerlScripts/subtract.pl
@@ -13,8 +13,10 @@ use strict;
 #           
 #
 # COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
+#                   CASAS (Center for the Analysis of Sustainable
+#                   Agricultural Systems, https://www.casasglobal.org/)
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#                   SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/PerlScripts/subtract.pl
+++ b/casas_gis_old/PerlScripts/subtract.pl
@@ -14,10 +14,7 @@ use strict;
 #
 # COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
-#
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/PerlScripts/test.pl
+++ b/casas_gis_old/PerlScripts/test.pl
@@ -4,7 +4,7 @@ use strict;
 # g.parser demo script
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # %Module

--- a/casas_gis_old/PerlScripts/test.pl
+++ b/casas_gis_old/PerlScripts/test.pl
@@ -3,7 +3,8 @@ use strict;
 
 # g.parser demo script
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # %Module

--- a/casas_gis_old/PerlScripts/test.pl
+++ b/casas_gis_old/PerlScripts/test.pl
@@ -3,6 +3,9 @@ use strict;
 
 # g.parser demo script
 
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # %Module
 # % description: g.parser test script (perl)
 # % keywords: keyword1, keyword2

--- a/casas_gis_old/PerlScripts/voroparse.pl
+++ b/casas_gis_old/PerlScripts/voroparse.pl
@@ -2,7 +2,9 @@
 # Script that transforms a string with categories
 # of Voronoi polygons containing zero value points
 # to a formula suitable for use in GRASS v.extract
+
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 4 Aprile 2006
 
 use strict;

--- a/casas_gis_old/PerlScripts/voroparse.pl
+++ b/casas_gis_old/PerlScripts/voroparse.pl
@@ -3,7 +3,8 @@
 # of Voronoi polygons containing zero value points
 # to a formula suitable for use in GRASS v.extract
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 4 Aprile 2006
 

--- a/casas_gis_old/PerlScripts/voroparse.pl
+++ b/casas_gis_old/PerlScripts/voroparse.pl
@@ -4,7 +4,7 @@
 # to a formula suitable for use in GRASS v.extract
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2006 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 4 Aprile 2006
 

--- a/casas_gis_old/casas/Andalusia GUI.bat
+++ b/casas_gis_old/casas/Andalusia GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Andalusia GUI.bat
+++ b/casas_gis_old/casas/Andalusia GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Andalusia GUI.bat
+++ b/casas_gis_old/casas/Andalusia GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Andalusia SHELL.bat
+++ b/casas_gis_old/casas/Andalusia SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Andalusia SHELL.bat
+++ b/casas_gis_old/casas/Andalusia SHELL.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Andalusia SHELL.bat
+++ b/casas_gis_old/casas/Andalusia SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Colombia GUI.bat
+++ b/casas_gis_old/casas/Colombia GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Colombia GUI.bat
+++ b/casas_gis_old/casas/Colombia GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Colombia GUI.bat
+++ b/casas_gis_old/casas/Colombia GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Colombia SHELL.bat
+++ b/casas_gis_old/casas/Colombia SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Colombia SHELL.bat
+++ b/casas_gis_old/casas/Colombia SHELL.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Colombia SHELL.bat
+++ b/casas_gis_old/casas/Colombia SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
+++ b/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
+++ b/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
+++ b/casas_gis_old/casas/Europe and Med Basin Grape GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/India GUI.bat
+++ b/casas_gis_old/casas/India GUI.bat
@@ -1,4 +1,6 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also

--- a/casas_gis_old/casas/India GUI.bat
+++ b/casas_gis_old/casas/India GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/India GUI.bat
+++ b/casas_gis_old/casas/India GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/India SHELL.bat
+++ b/casas_gis_old/casas/India SHELL.bat
@@ -1,4 +1,6 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also

--- a/casas_gis_old/casas/India SHELL.bat
+++ b/casas_gis_old/casas/India SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/India SHELL.bat
+++ b/casas_gis_old/casas/India SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Italia GUI.bat
+++ b/casas_gis_old/casas/Italia GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Italia GUI.bat
+++ b/casas_gis_old/casas/Italia GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Italia GUI.bat
+++ b/casas_gis_old/casas/Italia GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Libya & Tunisia GUI.bat
+++ b/casas_gis_old/casas/Libya & Tunisia GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Libya & Tunisia GUI.bat
+++ b/casas_gis_old/casas/Libya & Tunisia GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Libya & Tunisia GUI.bat
+++ b/casas_gis_old/casas/Libya & Tunisia GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Libya & Tunisia SHELL.bat
+++ b/casas_gis_old/casas/Libya & Tunisia SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Libya & Tunisia SHELL.bat
+++ b/casas_gis_old/casas/Libya & Tunisia SHELL.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Libya & Tunisia SHELL.bat
+++ b/casas_gis_old/casas/Libya & Tunisia SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Mediterranean Basin GUI.bat
+++ b/casas_gis_old/casas/Mediterranean Basin GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Mediterranean Basin GUI.bat
+++ b/casas_gis_old/casas/Mediterranean Basin GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Mediterranean Basin GUI.bat
+++ b/casas_gis_old/casas/Mediterranean Basin GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Mediterranean Basin SHELL.bat
+++ b/casas_gis_old/casas/Mediterranean Basin SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/Mediterranean Basin SHELL.bat
+++ b/casas_gis_old/casas/Mediterranean Basin SHELL.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/Mediterranean Basin SHELL.bat
+++ b/casas_gis_old/casas/Mediterranean Basin SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/United States GUI.bat
+++ b/casas_gis_old/casas/United States GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/United States GUI.bat
+++ b/casas_gis_old/casas/United States GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/United States GUI.bat
+++ b/casas_gis_old/casas/United States GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/United States SHELL.bat
+++ b/casas_gis_old/casas/United States SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/United States SHELL.bat
+++ b/casas_gis_old/casas/United States SHELL.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/United States SHELL.bat
+++ b/casas_gis_old/casas/United States SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/africa GUI.bat
+++ b/casas_gis_old/casas/africa GUI.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/africa GUI.bat
+++ b/casas_gis_old/casas/africa GUI.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also
 REM ~ run in an rxvt Window, which is rather unreliable.

--- a/casas_gis_old/casas/africa GUI.bat
+++ b/casas_gis_old/casas/africa GUI.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/bin/EurMedGrape.bat
+++ b/casas_gis_old/casas/bin/EurMedGrape.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/EurMedGrape" %*'

--- a/casas_gis_old/casas/bin/EurMedGrape.bat
+++ b/casas_gis_old/casas/bin/EurMedGrape.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/EurMedGrape" %*'

--- a/casas_gis_old/casas/bin/EurMedGrape.bat
+++ b/casas_gis_old/casas/bin/EurMedGrape.bat
@@ -1,1 +1,5 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/EurMedGrape" %*'

--- a/casas_gis_old/casas/bin/LibyaTunisia.bat
+++ b/casas_gis_old/casas/bin/LibyaTunisia.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/LibyaTunisia" %*'

--- a/casas_gis_old/casas/bin/LibyaTunisia.bat
+++ b/casas_gis_old/casas/bin/LibyaTunisia.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/LibyaTunisia.bat
+++ b/casas_gis_old/casas/bin/LibyaTunisia.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/MedPresentClimate.bat
+++ b/casas_gis_old/casas/bin/MedPresentClimate.bat
@@ -1,1 +1,5 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/MedPresentClimate" %*'

--- a/casas_gis_old/casas/bin/MedPresentClimate.bat
+++ b/casas_gis_old/casas/bin/MedPresentClimate.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/MedPresentClimate" %*'

--- a/casas_gis_old/casas/bin/MedPresentClimate.bat
+++ b/casas_gis_old/casas/bin/MedPresentClimate.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/MedPresentClimate" %*'

--- a/casas_gis_old/casas/bin/africa.bat
+++ b/casas_gis_old/casas/bin/africa.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/africa" %*'

--- a/casas_gis_old/casas/bin/africa.bat
+++ b/casas_gis_old/casas/bin/africa.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/africa" %*'

--- a/casas_gis_old/casas/bin/africa.bat
+++ b/casas_gis_old/casas/bin/africa.bat
@@ -1,1 +1,5 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/africa" %*'

--- a/casas_gis_old/casas/bin/india.bat
+++ b/casas_gis_old/casas/bin/india.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/india.bat
+++ b/casas_gis_old/casas/bin/india.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/india" %*'

--- a/casas_gis_old/casas/bin/india.bat
+++ b/casas_gis_old/casas/bin/india.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/italia.bat
+++ b/casas_gis_old/casas/bin/italia.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/italia.bat
+++ b/casas_gis_old/casas/bin/italia.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/italia" %*'

--- a/casas_gis_old/casas/bin/italia.bat
+++ b/casas_gis_old/casas/bin/italia.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/map.pbdm.andalusia" %*'

--- a/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.andalusia.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/map.pbdm.colombia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.colombia.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/map.pbdm.colombia" %*'

--- a/casas_gis_old/casas/bin/map.pbdm.colombia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.colombia.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/map.pbdm.colombia.bat
+++ b/casas_gis_old/casas/bin/map.pbdm.colombia.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/printCols.bat
+++ b/casas_gis_old/casas/bin/printCols.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/printCols.bat
+++ b/casas_gis_old/casas/bin/printCols.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @perl "%HOME%/PerlScripts/printCols.pl" "%HOME%"

--- a/casas_gis_old/casas/bin/printCols.bat
+++ b/casas_gis_old/casas/bin/printCols.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/usa.bat
+++ b/casas_gis_old/casas/bin/usa.bat
@@ -1,2 +1,6 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%
 @"%GRASS_SH%" -c '"%HOME%/casas/grass_scripts/usa" %*'

--- a/casas_gis_old/casas/bin/usa.bat
+++ b/casas_gis_old/casas/bin/usa.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/bin/usa.bat
+++ b/casas_gis_old/casas/bin/usa.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 @set PATH=%GISBASE%\scripts\;C:\Program Files\Mozilla Firefox\;%PATH%

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -29,9 +29,7 @@
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -25,7 +25,7 @@
 #						countries.
 #				2022-11-11 Added ability to save raster output as GeoTIFF.
 #
-# COPYRIGHT:    (c) 2005-2019 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2019 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -13,7 +13,7 @@
 # NOTE:         This version supports outfiles with names of
 #                       type "Olive_02Mar06_00003.txt".
 #
-# COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -17,9 +17,7 @@
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -15,7 +15,7 @@
 #                       Voronoi part was reimplemented as in Mediterraneo
 #                       and flag -s removed because no longer used.
 #
-# COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -19,9 +19,7 @@
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -23,9 +23,7 @@
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -19,7 +19,7 @@
 #				2022-11-24 (first release)
 #               2024-07-26 Ability to clip for cassava crop area
 #
-# COPYRIGHT:    (c) 2005-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2024 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -14,7 +14,7 @@
 #                       type "Cotton_02Mar06_00003.txt".
 #
 #
-# COPYRIGHT:    (c) 2005-2013 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2013 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -18,9 +18,7 @@
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -14,7 +14,7 @@
 #                       type "Olive_02Mar06_00003.txt".
 #
 #
-# COPYRIGHT:    (c) 2005-2012 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -18,9 +18,7 @@
 #                       of Sustainable Agricultural Systems).
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -32,7 +32,7 @@
 #						original area and to save raster output as GeoTIFF
 
 #
-# COPYRIGHT:    (c) 2005-2021 CASAS Global (Center for the Analysis
+# Copyright:    (c) 2005-2021 CASAS Global (Center for the Analysis
 #                       of Sustainable Agricultural Systems Global
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -36,9 +36,7 @@
 #                       of Sustainable Agricultural Systems Global
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -31,9 +31,7 @@
 #                       of Sustainable Agricultural Systems Global
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -27,7 +27,7 @@
 #                       which mapping will occur. Works for entire region
 #                       or subset of countries.
 #
-# COPYRIGHT:    (c) 2005-2019 CASAS Global (Center for the Analysis
+# Copyright:    (c) 2005-2019 CASAS Global (Center for the Analysis
 #                       of Sustainable Agricultural Systems Global
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -27,7 +27,7 @@
 #						countries.
 #
 #
-# COPYRIGHT:    (c) 2005-2020 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2020 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -31,9 +31,7 @@
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/casas/impact2c SHELL.bat
+++ b/casas_gis_old/casas/impact2c SHELL.bat
@@ -1,4 +1,6 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:
 REM ~ If you start MSys via the msys.bat it will set PATH, but it will also

--- a/casas_gis_old/casas/impact2c SHELL.bat
+++ b/casas_gis_old/casas/impact2c SHELL.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/impact2c SHELL.bat
+++ b/casas_gis_old/casas/impact2c SHELL.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 REM ~ Glynn Clements's suggestion:

--- a/casas_gis_old/casas/mounts.bat
+++ b/casas_gis_old/casas/mounts.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 c:\cygwin\bin\mount -f -s -b "C:/cygwin/bin" "/usr/bin"

--- a/casas_gis_old/casas/mounts.bat
+++ b/casas_gis_old/casas/mounts.bat
@@ -1,3 +1,7 @@
+@echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 c:\cygwin\bin\mount -f -s -b "C:/cygwin/bin" "/usr/bin"
 c:\cygwin\bin\mount -f -s -b "C:/cygwin/lib" "/usr/lib"
 c:\cygwin\bin\mount -f -s -b "C:/cygwin" "/"

--- a/casas_gis_old/casas/mounts.bat
+++ b/casas_gis_old/casas/mounts.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 c:\cygwin\bin\mount -f -s -b "C:/cygwin/bin" "/usr/bin"

--- a/casas_gis_old/casas/test.bat
+++ b/casas_gis_old/casas/test.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 for /L %%G in (1,1,10) do (

--- a/casas_gis_old/casas/test.bat
+++ b/casas_gis_old/casas/test.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 for /L %%G in (1,1,10) do (
 if %%G EQU 3 (
 echo %%G

--- a/casas_gis_old/casas/test.bat
+++ b/casas_gis_old/casas/test.bat
@@ -1,5 +1,6 @@
 @echo off
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 for /L %%G in (1,1,10) do (

--- a/casas_gis_old/outfiles/DivPrcpBy4.pl
+++ b/casas_gis_old/outfiles/DivPrcpBy4.pl
@@ -8,6 +8,7 @@
 # compilation.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 June 2010
 
 # Syntax:

--- a/casas_gis_old/outfiles/DivPrcpBy4.pl
+++ b/casas_gis_old/outfiles/DivPrcpBy4.pl
@@ -7,7 +7,8 @@
 # which was however already averaged during wx file
 # compilation.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 June 2010
 

--- a/casas_gis_old/outfiles/DivPrcpBy4.pl
+++ b/casas_gis_old/outfiles/DivPrcpBy4.pl
@@ -8,7 +8,7 @@
 # compilation.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 June 2010
 

--- a/casas_gis_old/outfiles/PerlShell.bat
+++ b/casas_gis_old/outfiles/PerlShell.bat
@@ -1,8 +1,10 @@
 @echo off
 
 REM Start a Perl-enabled DOS shell
-REM Author: Luigi Ponti (2007)
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2007 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
+REM Date: 2007
 
 set PATH=C:\Perl\bin;%PATH%;
 

--- a/casas_gis_old/outfiles/PerlShell.bat
+++ b/casas_gis_old/outfiles/PerlShell.bat
@@ -2,7 +2,7 @@
 
 REM Start a Perl-enabled DOS shell
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2007 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2007 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 REM Date: 2007
 

--- a/casas_gis_old/outfiles/PerlShell.bat
+++ b/casas_gis_old/outfiles/PerlShell.bat
@@ -1,7 +1,8 @@
 @echo off
 
-rem Start a Perl-enabled DOS shell
-rem Author: Luigi Ponti (2007)
+REM Start a Perl-enabled DOS shell
+REM Author: Luigi Ponti (2007)
+REM SPDX-License-Identifier: GPL-2.0-or-later
 
 set PATH=C:\Perl\bin;%PATH%;
 

--- a/casas_gis_old/outfiles/StatSum.R
+++ b/casas_gis_old/outfiles/StatSum.R
@@ -3,7 +3,9 @@
 # and coefficient of variation. Let us have statistical software
 # compute the statistics.
 
-# Luigi Ponti quartese at gmail.com 7 April 2010
+# Author: Luigi Ponti quartese at gmail.com
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 10 April 2010
 
 # Updated 13 November 2010: fixedPart <- aggregate
 # replace by a simple array selction by rows and cols.

--- a/casas_gis_old/outfiles/StatSum.bat
+++ b/casas_gis_old/outfiles/StatSum.bat
@@ -1,1 +1,4 @@
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 "C:\Program Files\R\R-3.5.1\bin\Rscript" StatSum.R --max-mem-size=1800M

--- a/casas_gis_old/outfiles/StatSum.bat
+++ b/casas_gis_old/outfiles/StatSum.bat
@@ -1,5 +1,5 @@
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 "C:\Program Files\R\R-3.5.1\bin\Rscript" StatSum.R --max-mem-size=1800M

--- a/casas_gis_old/outfiles/StatSum.bat
+++ b/casas_gis_old/outfiles/StatSum.bat
@@ -1,4 +1,5 @@
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 "C:\Program Files\R\R-3.5.1\bin\Rscript" StatSum.R --max-mem-size=1800M

--- a/casas_gis_old/outfiles/SubtractOutput.pl
+++ b/casas_gis_old/outfiles/SubtractOutput.pl
@@ -5,6 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 
 # Syntax:

--- a/casas_gis_old/outfiles/SubtractOutput.pl
+++ b/casas_gis_old/outfiles/SubtractOutput.pl
@@ -5,7 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/outfiles/SubtractOutput.pl
+++ b/casas_gis_old/outfiles/SubtractOutput.pl
@@ -4,7 +4,8 @@
 # in CASAS model outputs. NOTE: the script is supposed
 # to use files with the same number of rows & columns.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/outfiles/boxplotOutliersForMapping.R
+++ b/casas_gis_old/outfiles/boxplotOutliersForMapping.R
@@ -1,6 +1,7 @@
 # Code notebook for Naples 2013.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Set working directory.

--- a/casas_gis_old/outfiles/boxplotOutliersForMapping.R
+++ b/casas_gis_old/outfiles/boxplotOutliersForMapping.R
@@ -1,7 +1,7 @@
 # Code notebook for Naples 2013.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Set working directory.

--- a/casas_gis_old/outfiles/boxplotOutliersForMapping.R
+++ b/casas_gis_old/outfiles/boxplotOutliersForMapping.R
@@ -1,5 +1,8 @@
 # Code notebook for Naples 2013.
 
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # Set working directory.
 setwd("H:\\maxtor_mirror\\pending papers\\OliveFly_Desertification\\SPA-IntConference-Naples2013")
 

--- a/casas_gis_old/outfiles/fileRename.pl
+++ b/casas_gis_old/outfiles/fileRename.pl
@@ -1,6 +1,9 @@
 #!/usr/bin/perl -w
 # http://ekawas.blogspot.com/2008/11/perl-script-to-rename-your-files.html
 
+# Author: Edward Kawas, Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # e.g. 
 # for %v in (*.txt) do perl fileRename.pl -u "s/cln//g" "%v"
 

--- a/casas_gis_old/outfiles/fileRename.pl
+++ b/casas_gis_old/outfiles/fileRename.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 # http://ekawas.blogspot.com/2008/11/perl-script-to-rename-your-files.html
 
-# Author: Edward Kawas, Luigi Ponti
+# Authors: Edward Kawas, Luigi Ponti quartese gmail.com
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # e.g. 

--- a/casas_gis_old/outfiles/fileRename2.pl
+++ b/casas_gis_old/outfiles/fileRename2.pl
@@ -3,7 +3,8 @@
 # Usage: perl fileNewName.pl perlexpr [files]
 # Example: fileRename2.pl "s/med//" *.txt
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use File::Glob qw(:glob);

--- a/casas_gis_old/outfiles/fileRename2.pl
+++ b/casas_gis_old/outfiles/fileRename2.pl
@@ -3,6 +3,9 @@
 # Usage: perl fileNewName.pl perlexpr [files]
 # Example: fileRename2.pl "s/med//" *.txt
 
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 use File::Glob qw(:glob);
 
 ($regexp = shift @ARGV) || die "Usage:  rename perlexpr [filenames]\n";

--- a/casas_gis_old/outfiles/fileRename2.pl
+++ b/casas_gis_old/outfiles/fileRename2.pl
@@ -4,7 +4,7 @@
 # Example: fileRename2.pl "s/med//" *.txt
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 use File::Glob qw(:glob);

--- a/casas_gis_old/outfiles/getCustomColorRule.pl
+++ b/casas_gis_old/outfiles/getCustomColorRule.pl
@@ -5,7 +5,8 @@
 # Can use any combination of colors.
 # The central color may be placed at an arbitrary value ($scaleCenter).
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 29 June 2010
 

--- a/casas_gis_old/outfiles/getCustomColorRule.pl
+++ b/casas_gis_old/outfiles/getCustomColorRule.pl
@@ -3,10 +3,10 @@
 # of colors and the range of data.
 
 # Can use any combination of colors.
-
 # The central color may be placed at an arbitrary value ($scaleCenter).
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 29 June 2010
 
 use strict;

--- a/casas_gis_old/outfiles/getCustomColorRule.pl
+++ b/casas_gis_old/outfiles/getCustomColorRule.pl
@@ -6,7 +6,7 @@
 # The central color may be placed at an arbitrary value ($scaleCenter).
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 29 June 2010
 

--- a/casas_gis_old/outfiles/lineRemove.pl
+++ b/casas_gis_old/outfiles/lineRemove.pl
@@ -2,6 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 
 use strict;

--- a/casas_gis_old/outfiles/lineRemove.pl
+++ b/casas_gis_old/outfiles/lineRemove.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 # Script that removes lines with a certain regex by writing
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 

--- a/casas_gis_old/outfiles/lineRemove.pl
+++ b/casas_gis_old/outfiles/lineRemove.pl
@@ -2,7 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 

--- a/casas_gis_old/outfiles/lineSelect.pl
+++ b/casas_gis_old/outfiles/lineSelect.pl
@@ -6,7 +6,7 @@
 # lineRmove.pl being actrually sea location).
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 

--- a/casas_gis_old/outfiles/lineSelect.pl
+++ b/casas_gis_old/outfiles/lineSelect.pl
@@ -6,6 +6,7 @@
 # lineRmove.pl being actrually sea location).
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 
 use strict;

--- a/casas_gis_old/outfiles/lineSelect.pl
+++ b/casas_gis_old/outfiles/lineSelect.pl
@@ -5,7 +5,8 @@
 # some of them were removed previously with
 # lineRmove.pl being actrually sea location).
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 3 July 2010
 

--- a/casas_gis_old/outfiles/old_StatSum.R
+++ b/casas_gis_old/outfiles/old_StatSum.R
@@ -3,7 +3,9 @@
 # and coefficient of variation. Let us have statistical software
 # compute the statistics.
 
-# Luigi Ponti quartese at gmail.com 7 April 2010
+# Author: Luigi Ponti quartese at gmail.com
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 7 April 2010
 
 # Updated 13 November 2010: fixedPart <- aggregate
 # replace by a simple array selction by rows and cols.

--- a/casas_gis_old/outfiles/replaceStrFile.bat
+++ b/casas_gis_old/outfiles/replaceStrFile.bat
@@ -1,2 +1,4 @@
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
 
 for %%f in (*.txt) do perl -pi.bak -e "s/\//Per/g" %%f

--- a/casas_gis_old/outfiles/replaceStrFile.bat
+++ b/casas_gis_old/outfiles/replaceStrFile.bat
@@ -1,5 +1,5 @@
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 for %%f in (*.txt) do perl -pi.bak -e "s/\//Per/g" %%f

--- a/casas_gis_old/outfiles/replaceStrFile.bat
+++ b/casas_gis_old/outfiles/replaceStrFile.bat
@@ -1,4 +1,5 @@
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 for %%f in (*.txt) do perl -pi.bak -e "s/\//Per/g" %%f

--- a/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
+++ b/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 # Script that removes lines with a certain regex by writing
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 27 November 2010
 

--- a/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
+++ b/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
@@ -2,7 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 27 November 2010
 

--- a/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
+++ b/casas_gis_old/outfiles/selectOliveGrowingAreaGrid_NEW.pl
@@ -2,6 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 27 November 2010
 
 use strict;

--- a/casas_gis_old/outfiles/select_29_Med_outliers.pl
+++ b/casas_gis_old/outfiles/select_29_Med_outliers.pl
@@ -2,6 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 July 2009
 
 use strict;

--- a/casas_gis_old/outfiles/select_29_Med_outliers.pl
+++ b/casas_gis_old/outfiles/select_29_Med_outliers.pl
@@ -2,7 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 July 2009
 

--- a/casas_gis_old/outfiles/select_29_Med_outliers.pl
+++ b/casas_gis_old/outfiles/select_29_Med_outliers.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 # Script that removes lines with a certain regex by writing
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 20 July 2009
 

--- a/casas_gis_old/outfiles/select_MedOlive_995.pl
+++ b/casas_gis_old/outfiles/select_MedOlive_995.pl
@@ -2,7 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 December 2011
 

--- a/casas_gis_old/outfiles/select_MedOlive_995.pl
+++ b/casas_gis_old/outfiles/select_MedOlive_995.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 # Script that removes lines with a certain regex by writing
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 December 2011
 

--- a/casas_gis_old/outfiles/select_MedOlive_995.pl
+++ b/casas_gis_old/outfiles/select_MedOlive_995.pl
@@ -2,6 +2,7 @@
 # Script that removes lines with a certain regex by writing
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 14 December 2011
 
 # select_MedOlive_995.pl

--- a/casas_gis_old/outfiles/subtractMajorRevision.bat
+++ b/casas_gis_old/outfiles/subtractMajorRevision.bat
@@ -1,5 +1,5 @@
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 REM Date: 16 December 2011
 

--- a/casas_gis_old/outfiles/subtractMajorRevision.bat
+++ b/casas_gis_old/outfiles/subtractMajorRevision.bat
@@ -1,8 +1,9 @@
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
+REM Date: 16 December 2011
 
 REM Make difference files for MedOlive major revision manuscript
-REM Date: 16 December 2011
 
 :: ERA40 no fly
 perl SubtractOutput.pl "" Olive_08dic11_Avg_ERA40_pl2_noFly.txt Olive_08dic11_Avg_ERA40_obs_noFly.txt Olive_08dic11_Avg_ERA40_Delta_noFly.txt

--- a/casas_gis_old/outfiles/subtractMajorRevision.bat
+++ b/casas_gis_old/outfiles/subtractMajorRevision.bat
@@ -1,5 +1,8 @@
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 REM Make difference files for MedOlive major revision manuscript
-REM 16 December 2011, Luigi Ponti.
+REM Date: 16 December 2011
 
 :: ERA40 no fly
 perl SubtractOutput.pl "" Olive_08dic11_Avg_ERA40_pl2_noFly.txt Olive_08dic11_Avg_ERA40_obs_noFly.txt Olive_08dic11_Avg_ERA40_Delta_noFly.txt

--- a/casas_gis_old/outfiles/writeFileList.bat
+++ b/casas_gis_old/outfiles/writeFileList.bat
@@ -2,7 +2,7 @@
 @echo off
 
 REM Author: Luigi Ponti quartese gmail.com
-REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+REM Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 dir /B *txt | find /V /I "GisFilesList.txt" > GisFilesList.txt

--- a/casas_gis_old/outfiles/writeFileList.bat
+++ b/casas_gis_old/outfiles/writeFileList.bat
@@ -1,3 +1,7 @@
 :: Recreates GisFilesList.txt
 @echo off
+
+REM Author: Luigi Ponti
+REM SPDX-License-Identifier: GPL-2.0-or-later
+
 dir /B *txt | find /V /I "GisFilesList.txt" > GisFilesList.txt

--- a/casas_gis_old/outfiles/writeFileList.bat
+++ b/casas_gis_old/outfiles/writeFileList.bat
@@ -1,7 +1,8 @@
 :: Recreates GisFilesList.txt
 @echo off
 
-REM Author: Luigi Ponti
+REM Author: Luigi Ponti quartese gmail.com
+REM COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 REM SPDX-License-Identifier: GPL-2.0-or-later
 
 dir /B *txt | find /V /I "GisFilesList.txt" > GisFilesList.txt

--- a/casas_gis_old/scripts/CASAS_GIS_map_list.sh
+++ b/casas_gis_old/scripts/CASAS_GIS_map_list.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 g.laptop_non_interactive.sh -r newLocation=a_med_test rasterList=era40_67_270_10_grow vectorList=croatia

--- a/casas_gis_old/scripts/CASAS_GIS_map_list.sh
+++ b/casas_gis_old/scripts/CASAS_GIS_map_list.sh
@@ -1,1 +1,6 @@
+#!/bin/sh
+#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 g.laptop_non_interactive.sh -r newLocation=a_med_test rasterList=era40_67_270_10_grow vectorList=croatia

--- a/casas_gis_old/scripts/CASAS_GIS_map_list.sh
+++ b/casas_gis_old/scripts/CASAS_GIS_map_list.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 g.laptop_non_interactive.sh -r newLocation=a_med_test rasterList=era40_67_270_10_grow vectorList=croatia

--- a/casas_gis_old/scripts/DosUnix.sh
+++ b/casas_gis_old/scripts/DosUnix.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # set -x
 # Convert windows text file to a Unix text file.
+
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 cd ~/outfiles/
 
 echo ""

--- a/casas_gis_old/scripts/DosUnix.sh
+++ b/casas_gis_old/scripts/DosUnix.sh
@@ -3,7 +3,7 @@
 # Convert windows text file to a Unix text file.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 cd ~/outfiles/

--- a/casas_gis_old/scripts/DosUnix.sh
+++ b/casas_gis_old/scripts/DosUnix.sh
@@ -2,7 +2,8 @@
 # set -x
 # Convert windows text file to a Unix text file.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 cd ~/outfiles/

--- a/casas_gis_old/scripts/MediterraneoBatchRun.sh
+++ b/casas_gis_old/scripts/MediterraneoBatchRun.sh
@@ -2,7 +2,9 @@
 #
 # Batch run mediterraneo CASAS GIS
 #
-# Luigi Ponti, 10 July 2009
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 10 July 2009
 #
 
 #~ 12. dd

--- a/casas_gis_old/scripts/MediterraneoBatchRun.sh
+++ b/casas_gis_old/scripts/MediterraneoBatchRun.sh
@@ -2,7 +2,8 @@
 #
 # Batch run mediterraneo CASAS GIS
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 July 2009
 #

--- a/casas_gis_old/scripts/MediterraneoBatchRun.sh
+++ b/casas_gis_old/scripts/MediterraneoBatchRun.sh
@@ -3,7 +3,7 @@
 # Batch run mediterraneo CASAS GIS
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2009 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 July 2009
 #

--- a/casas_gis_old/scripts/SubtractOutput.pl
+++ b/casas_gis_old/scripts/SubtractOutput.pl
@@ -5,6 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 
 # Syntax:

--- a/casas_gis_old/scripts/SubtractOutput.pl
+++ b/casas_gis_old/scripts/SubtractOutput.pl
@@ -5,7 +5,7 @@
 # to use files with the same number of rows & columns.
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/scripts/SubtractOutput.pl
+++ b/casas_gis_old/scripts/SubtractOutput.pl
@@ -4,7 +4,8 @@
 # in CASAS model outputs. NOTE: the script is supposed
 # to use files with the same number of rows & columns.
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2008 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 22 January 2008
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_LibyaTunisia_screwworm.sh
 #
-# Luigi Ponti, 18 June 2012
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 18 June 2012
 
 #~ The following column names were found:
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_LibyaTunisia_screwworm.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 18 June 2012
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_screwworm.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_LibyaTunisia_screwworm.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 18 June 2012
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_LibyaTunisia_sw_majorRev.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 18 June 2012
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_LibyaTunisia_sw_majorRev.sh
 #
-# Luigi Ponti, 18 June 2012
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 18 June 2012
 
 #~ The following column names
 

--- a/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
+++ b/casas_gis_old/scripts/batch_LibyaTunisia_sw_majorRev.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_LibyaTunisia_sw_majorRev.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 18 June 2012
 

--- a/casas_gis_old/scripts/batch_OliveProtheus.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_OliveProtheus.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 17 March 2010
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 17 March 2010
 
 #~ No fly:
 

--- a/casas_gis_old/scripts/batch_OliveProtheus.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 01 September 2011
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 01 September 2011
 
 #~ 1. Model
 #~ 2. Date

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 01 September 2011
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 01 September 2011
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2014 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2014 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 07 Jan 2014
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 07 Jan 2014
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 07 Jan 2014
 
 #~ YIELD
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_Bioeconomics_PNAS.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2014 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 07 Jan 2014
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
@@ -7,7 +7,8 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 March 2012
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
@@ -7,8 +7,9 @@
 # To run it from 64-SVN DOS text, please enter
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 10 March 2012
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 10 March 2012
 
 #~ 28. OfPupSum
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_BlackWhite.sh
@@ -8,7 +8,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2012 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 10 March 2012
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
@@ -2,7 +2,8 @@
 #
 # Batch run medPresentClimate CASAS GIS
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
@@ -2,8 +2,9 @@
 #
 # Batch run medPresentClimate CASAS GIS
 #
-# Luigi Ponti, 17 March 2010
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 17 March 2010
 
 #~ 1. Model
 #~ 2. Date

--- a/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
+++ b/casas_gis_old/scripts/batch_OliveProtheus_mapsOfChange.sh
@@ -3,7 +3,7 @@
 # Batch run medPresentClimate CASAS GIS
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_USA_olive.sh
+++ b/casas_gis_old/scripts/batch_USA_olive.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_USA_olive.sh
+++ b/casas_gis_old/scripts/batch_USA_olive.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 17 March 2010
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 17 March 2010
 
 #~ No fly:
 

--- a/casas_gis_old/scripts/batch_USA_olive.sh
+++ b/casas_gis_old/scripts/batch_USA_olive.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_USA_screwworm.sh
+++ b/casas_gis_old/scripts/batch_USA_screwworm.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 November 2011
 #

--- a/casas_gis_old/scripts/batch_USA_screwworm.sh
+++ b/casas_gis_old/scripts/batch_USA_screwworm.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2011 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 November 2011
 #

--- a/casas_gis_old/scripts/batch_USA_screwworm.sh
+++ b/casas_gis_old/scripts/batch_USA_screwworm.sh
@@ -5,7 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 17 November 2011
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 17 November 2011
 #
 
 #~ The following column names were found:

--- a/casas_gis_old/scripts/batch_coffee_colombia.sh
+++ b/casas_gis_old/scripts/batch_coffee_colombia.sh
@@ -6,7 +6,7 @@
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_coffee_colombia.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 02 October 2019
 

--- a/casas_gis_old/scripts/batch_coffee_colombia.sh
+++ b/casas_gis_old/scripts/batch_coffee_colombia.sh
@@ -5,7 +5,8 @@
 # Run from Colombia shell with following command
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_coffee_colombia.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 02 October 2019
 

--- a/casas_gis_old/scripts/batch_coffee_colombia.sh
+++ b/casas_gis_old/scripts/batch_coffee_colombia.sh
@@ -5,8 +5,9 @@
 # Run from Colombia shell with following command
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_coffee_colombia.sh
 #
-# Luigi Ponti, 02 October 2019
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 02 October 2019
 
 # NASA Panoply
 # "4:14:216-32:80:255-65:150:255-109:193:255-134:217:255-156:238:255-175:245:255-206:255:255-255:254:71-255:235:0-255:196:0-255:144:0-255:72:0-255:0:0-213:0:0-158:0:0"

--- a/casas_gis_old/scripts/batch_india_cotton.sh
+++ b/casas_gis_old/scripts/batch_india_cotton.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_india_cotton.sh
 #
-# Luigi Ponti, 7 October 2013
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 7 October 2013
 
 #~ The following column names were found:
 

--- a/casas_gis_old/scripts/batch_india_cotton.sh
+++ b/casas_gis_old/scripts/batch_india_cotton.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_india_cotton.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 7 October 2013
 

--- a/casas_gis_old/scripts/batch_india_cotton.sh
+++ b/casas_gis_old/scripts/batch_india_cotton.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_india_cotton.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 7 October 2013
 

--- a/casas_gis_old/scripts/batch_olive_andalusia.sh
+++ b/casas_gis_old/scripts/batch_olive_andalusia.sh
@@ -5,7 +5,8 @@
 # Run from Andalusia shell with following command
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_olive_andalusia.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 02 October 2019
 

--- a/casas_gis_old/scripts/batch_olive_andalusia.sh
+++ b/casas_gis_old/scripts/batch_olive_andalusia.sh
@@ -5,8 +5,9 @@
 # Run from Andalusia shell with following command
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_olive_andalusia.sh
 #
-# Luigi Ponti, 02 October 2019
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 02 October 2019
 
 # -r and -p flags are for raster stat report and histograms
 

--- a/casas_gis_old/scripts/batch_olive_andalusia.sh
+++ b/casas_gis_old/scripts/batch_olive_andalusia.sh
@@ -6,7 +6,7 @@
 # "C:\Program Files (x86)\GRASS GIS 6.4.4\msys\bin\sh.exe" batch_olive_andalusia.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2019 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 02 October 2019
 

--- a/casas_gis_old/scripts/batch_swd_EU.sh
+++ b/casas_gis_old/scripts/batch_swd_EU.sh
@@ -5,7 +5,8 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/batch_swd_EU.sh
+++ b/casas_gis_old/scripts/batch_swd_EU.sh
@@ -5,8 +5,9 @@
 # To run it from 64-SVN DOS text, please e
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
-# Luigi Ponti, 17 March 2010
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 17 March 2010
 
 # 1. Model
 # 2. Date

--- a/casas_gis_old/scripts/batch_swd_EU.sh
+++ b/casas_gis_old/scripts/batch_swd_EU.sh
@@ -6,7 +6,7 @@
 # "%GRASS_SH%" batch_oliveProtheusWin.sh
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 17 March 2010
 

--- a/casas_gis_old/scripts/conv.sh
+++ b/casas_gis_old/scripts/conv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 cd ~/outfiles/

--- a/casas_gis_old/scripts/conv.sh
+++ b/casas_gis_old/scripts/conv.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Date: 
 
 cd ~/outfiles/
 echo

--- a/casas_gis_old/scripts/conv.sh
+++ b/casas_gis_old/scripts/conv.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 
+
 cd ~/outfiles/
 echo
 echo 'Please move files you want to convert into the "outfiles" folder,'

--- a/casas_gis_old/scripts/d.col.names
+++ b/casas_gis_old/scripts/d.col.names
@@ -3,7 +3,7 @@
 #
 # MODULE:       d.col.names
 #
-# AUTHOR(S):    Luigi Ponti
+# AUTHOR(S):    Luigi Ponti quartese gmail.com
 #
 # PURPOSE:      Read column names from CASAS models output files.
 #
@@ -12,8 +12,10 @@
 #                       It requires outfiles in "Olive_02Mar06_00002.txt" style.
 #
 # COPYRIGHT:    (c) 2006 Luigi Ponti lponti@nature.berkeley.edu
+#                   CASAS (Center for the Analysis of Sustainable Agricultural
+#                   Systems, https://www.casasglobal.org/)
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#                   SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/d.col.names
+++ b/casas_gis_old/scripts/d.col.names
@@ -13,10 +13,7 @@
 #
 # COPYRIGHT:    (c) 2006 Luigi Ponti lponti@nature.berkeley.edu
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
-#
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/g.laptop_non_interactive.sh
+++ b/casas_gis_old/scripts/g.laptop_non_interactive.sh
@@ -12,7 +12,7 @@
 #               location into a new one. Data can be copied or extracted
 #		        in current or original resolution and region extent.
 #
-# COPYRIGHT:    (C) 2002-2012 by the GRASS Development Team
+# Copyright:    (C) 2002-2012 by the GRASS Development Team
 #
 #               SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/g.laptop_non_interactive.sh
+++ b/casas_gis_old/scripts/g.laptop_non_interactive.sh
@@ -14,9 +14,7 @@
 #
 # COPYRIGHT:    (C) 2002-2012 by the GRASS Development Team
 #
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 # COMMENTS:     Sometimes extracting vector maps at current region extent
 #               with v.extract doesn't work properly - use copy instead!!

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
@@ -10,7 +10,7 @@
 #               - raster_convert_all_mapsets_G6_G8.sh
 #                  - GRASS GIS and within r.support.stats.all.sh
 # REQUIREMENTS: patched version of v.db.reconnect.all.py (fatal -> warning)
-# COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
+# Copyright:    (C) 2024 by Markus Neteler and the GRASS Development Team
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/process_grass6data_casas.sh
@@ -12,9 +12,7 @@
 # REQUIREMENTS: patched version of v.db.reconnect.all.py (fatal -> warning)
 # COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
@@ -6,7 +6,7 @@
 #             called by process_grass6data_casas.sh
 # AUTHOR(S):  Markus Neteler
 # PURPOSE:    update statistics of all raster maps in current mapset
-# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+# Copyright:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
 #		      SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/r.support.stats.all.sh
@@ -8,9 +8,7 @@
 # PURPOSE:    update statistics of all raster maps in current mapset
 # COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		      SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
@@ -6,7 +6,7 @@
 #             called by process_grass6data_casas.sh
 # AUTHOR(S):  Markus Neteler
 # PURPOSE:    updates raster statistics
-# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+# Copyright:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
 #		      SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/raster_convert_all_mapsets_G6_G8.sh
@@ -8,9 +8,7 @@
 # PURPOSE:    updates raster statistics
 # COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		      SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
@@ -11,7 +11,7 @@
 #               - removes empty dbf/ directory
 # REQUIREMENTS: patched v.db.reconnect.all.py (fatal -> warning),
 #               see v.db.reconnect.all.py.diff
-# COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
+# Copyright:    (C) 2024 by Markus Neteler and the GRASS Development Team
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/v.db.dbf2sqlite.all.sh
@@ -13,9 +13,7 @@
 #               see v.db.reconnect.all.py.diff
 # COPYRIGHT:    (C) 2024 by Markus Neteler and the GRASS Development Team
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
@@ -7,7 +7,7 @@
 # AUTHOR(S):  Markus Neteler
 # PURPOSE:    converts all mapsets in current directory tree from
 #             old DBF-based GRASS GIS vector maps to SQLite DB
-# COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
+# Copyright:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
 #		      SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
+++ b/casas_gis_old/scripts/gdata_conversion_G6_to_G8/vector_convert_all_mapsets_G6_G8.sh
@@ -9,9 +9,7 @@
 #             old DBF-based GRASS GIS vector maps to SQLite DB
 # COPYRIGHT:  (C) 2024 by Markus Neteler and the GRASS Development Team
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
+#		      SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/get_boxplot_stats.sh
+++ b/casas_gis_old/scripts/get_boxplot_stats.sh
@@ -17,7 +17,7 @@
 # to be in the same directory
 #
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 11 October 2013
 

--- a/casas_gis_old/scripts/get_boxplot_stats.sh
+++ b/casas_gis_old/scripts/get_boxplot_stats.sh
@@ -16,7 +16,8 @@
 # It expects (and colls) Perl script getBoxplotColorRule.pl
 # to be in the same directory
 #
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2013 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Date: 11 October 2013
 

--- a/casas_gis_old/scripts/get_boxplot_stats.sh
+++ b/casas_gis_old/scripts/get_boxplot_stats.sh
@@ -16,8 +16,9 @@
 # It expects (and colls) Perl script getBoxplotColorRule.pl
 # to be in the same directory
 #
-# Luigi Ponti, 11 October 2013
-#
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Date: 11 October 2013
 
 #~ cotton_harea_175crops2000_india
 #~ cotton_area_irrig_fraction_M3

--- a/casas_gis_old/scripts/make_new_GIS_location.sh
+++ b/casas_gis_old/scripts/make_new_GIS_location.sh
@@ -2,6 +2,9 @@
 
 #~ US-GIS
 
+# Author: Luigi Ponti
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 #~ Rasters:
 #~ US_dem US_conterm_60_315_10 natural_earth_color.composite
 

--- a/casas_gis_old/scripts/make_new_GIS_location.sh
+++ b/casas_gis_old/scripts/make_new_GIS_location.sh
@@ -2,7 +2,8 @@
 
 #~ US-GIS
 
-# Author: Luigi Ponti
+# Author: Luigi Ponti quartese gmail.com
+# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 #~ Rasters:

--- a/casas_gis_old/scripts/make_new_GIS_location.sh
+++ b/casas_gis_old/scripts/make_new_GIS_location.sh
@@ -3,7 +3,7 @@
 #~ US-GIS
 
 # Author: Luigi Ponti quartese gmail.com
-# COPYRIGHT: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
+# Copyright: (c) 2010 CASAS (Center for the Analysis of Sustainable Agricultural Systems, https://www.casasglobal.org/)
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 #~ Rasters:

--- a/casas_gis_old/scripts/r.colors.stddev
+++ b/casas_gis_old/scripts/r.colors.stddev
@@ -7,9 +7,8 @@
 # PURPOSE:      Set color rules based on stddev from a map's mean value.
 #
 # COPYRIGHT:    (c) 2007 Hamish Bowman, and the GRASS Development Team
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+#
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/subtract.sh
+++ b/casas_gis_old/scripts/subtract.sh
@@ -14,10 +14,7 @@
 #
 # COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
 #
-#		This program is free software under the GNU General Public
-#		License (>=v2). Read the file COPYING that comes with GRASS
-#		for details.
-#
+#		        SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/casas_gis_old/scripts/subtract.sh
+++ b/casas_gis_old/scripts/subtract.sh
@@ -12,7 +12,7 @@
 # NOTE:
 #
 #
-# COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
+# Copyright:    (c) 2008 Luigi Ponti, quartese at gmail.com
 #                   CASAS (Center for the Analysis of Sustainable
 #                   Agricultural Systems, https://www.casasglobal.org/)
 #

--- a/casas_gis_old/scripts/subtract.sh
+++ b/casas_gis_old/scripts/subtract.sh
@@ -13,8 +13,10 @@
 #
 #
 # COPYRIGHT:    (c) 2008 Luigi Ponti, quartese at gmail.com
+#                   CASAS (Center for the Analysis of Sustainable
+#                   Agricultural Systems, https://www.casasglobal.org/)
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#                   SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/template-demo/script.py
+++ b/template-demo/script.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 from pathlib import Path
 from string import Template
 

--- a/template-demo/script.py
+++ b/template-demo/script.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #

--- a/tests/test_casas_gis.py
+++ b/tests/test_casas_gis.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+#
+# AUTHOR(S):    Luigi Ponti quartese gmail com
+#
+# PURPOSE:      
+#
+# NOTE:         
+#
+# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+#                   of Sustainable Agricultural Systems).
+#                   https://www.casasglobal.org/).
+#
+#               SPDX-License-Identifier: GPL-3.0-or-later
+
 import pytest
 
 from casas_gis import __version__

--- a/tests/test_casas_gis.py
+++ b/tests/test_casas_gis.py
@@ -6,7 +6,7 @@
 #
 # NOTE:         
 #
-# COPYRIGHT:    (c) 2021-2024 CASAS (Center for the Analysis
+# Copyright:    (c) 2021-2024 CASAS (Center for the Analysis
 #                   of Sustainable Agricultural Systems).
 #                   https://www.casasglobal.org/).
 #


### PR DESCRIPTION
This PR adds in all relevant files header declarations:
- `casas_gis/`: `SPDX-License-Identifier: GPL-3.0-or-later`
- `casas_gis_old/`: `SPDX-License-Identifier: GPL-2.0-or-later`

Also:
- add CASAS COPYRIGHT and L. Ponti email
- add authors and, where possible, date declaration
- in a few cases also the Python shebang has been added.

If anything should be amended, please let me know.

Fixes #115