### PR TITLE
Alfalfa crop masking in EU and USA

### DIFF
--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -24,8 +24,10 @@
 #						option. Works for entire region or subset of
 #						countries.
 #				2022-11-11 Added ability to save raster output as GeoTIFF.
+#				2025-01-21 Added alflafa harvested area to the list of
+#                       crops for clipping model output.
 #
-# Copyright:    (c) 2005-2019 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2025 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #
@@ -137,7 +139,7 @@
 # % key: crop
 # % type: string
 # % answer: none
-# % options: grape, tomato_harvested,tomato_h_temperate,tomato_h_tropical,tomato_h_combined,none
+# % options: grape, tomato_harvested,tomato_h_temperate,tomato_h_tropical,tomato_h_combined,alfalfa_harvested,none
 # % description: Constrain output map to crop growing area (grape = grape growing area, tomato_harvested = observed from www.earthstat.org, tomato_h_temperate = harvested and temperature-constrained temperate cultivars from www.fao.org/nr/gaez, tomato_h_tropical = harvested and temperature-constrained tropical cultivars, tomato_h_combined = the previous two combined, none = no crop constraint)
 # % required: yes
 # %end
@@ -510,6 +512,9 @@ elif [ "$CROP" == "tomato_h_tropical" ]; then
     r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 elif [ "$CROP" == "tomato_h_combined" ]; then
     r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), Med_dem, null())'
+    r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
+elif [ "$CROP" == "alfalfa_harvested" ]; then
+    r.mapcalc 'ElevMask = if ((EtoSelectMask && alfalfa_harvarea_EurMedGrape_binary), US_dem, null())'
     r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # No crop constraint
 elif [ "$CROP" == "none" ]; then

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -14,20 +14,19 @@
 #                       type "Olive_02Mar06_00003.txt".
 #
 #				Updates:
-#				2020-06-05 Added ability to select countries in Central
-#						America (Belize, Guatemala, Honduras, El Salvador,
-#                       Nicaragua, Costa Rica, Panama) for use in the fruit
-#                       flies study). Uses a new projected location named
-#                       AEA_US_mex_central_america
-#
-#				Updates:
 #				2019-08-30 Added ability to use tomato (various extents)
 #						for clipping model output as a multiple choice
 #						option. Works for entire region or subset of
 #						countries.
+#				2020-06-05 Added ability to select countries in Central
+#						America (Belize, Guatemala, Honduras, El Salvador,
+#                       Nicaragua, Costa Rica, Panama) for use in the fruit
+#                       flies study). Uses a new projected location named
+#                       AEA_US_mex_central_america#
+#				2025-01-21 Added alflafa harvested area to the list of
+#                       crops for clipping model output.
 #
-#
-# Copyright:    (c) 2005-2020 CASAS (Center for the Analysis
+# Copyright:    (c) 2005-2025 CASAS (Center for the Analysis
 #                       of Sustainable Agricultural Systems
 #                       https://www.casasglobal.org/).
 #
@@ -210,8 +209,8 @@
 # %option
 # % key: crop
 # % type: string
-# % options: tomato_harvested,tomato_h_temperate,tomato_h_tropical,tomato_h_combined,none
-# % answer: tomato_h_combined
+# % options: tomato_harvested,tomato_h_temperate,tomato_h_tropical,tomato_h_combined,alfalfa_harvested,none
+# % answer: none
 # % description: Constrain output map to crop growing area (tomato_harvested = observed from www.earthstat.org, tomato_h_temperate = harvested and temperature-constrained temperate cultivars from www.fao.org/nr/gaez, tomato_h_tropical = harvested and temperature-constrained tropical cultivars, tomato_h_combined = the previous two combined, none = no crop constraint)
 # % required: yes
 # %end
@@ -588,7 +587,10 @@ elif [ "$CROP" == "tomato_h_tropical" ]; then
 elif [ "$CROP" == "tomato_h_combined" ]; then
     r.mapcalc 'ElevMask = if ((EtoSelectMask && tomato_y_175crops_t_gaez_combined), US_dem, null())'
     r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
-# Use no mask for model output
+elif [ "$CROP" == "alfalfa_harvested" ]; then
+    r.mapcalc 'ElevMask = if ((EtoSelectMask && alfalfa_harvarea_usa_binary), US_dem, null())'
+    r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
+# No crop constraint
 elif [ "$CROP" == "none" ]; then
     r.mapcalc 'ElevMask = if (EtoSelectMask, US_dem, null())'
     r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"


### PR DESCRIPTION
After adding an alfalfa crop layer from [CROPGRIDS](https://doi.org/10.1038/s41597-024-03247-7) for masking PBDM maps in North/Central America and Europe/Mediterranean, the related CASAS GIS scripts were modified to give the user an additional masking option.

@neteler what would be a reasonable way to update the CASAS GIS database accordingly? This would imply adding the raster map for alfalfa presence/absence in North/Central America and Europe/Mediterranean to the AEA_US_mex_central_america and AEA_Med GRASS locations (aka projects) of the [GRASS GIS database for CASAS-PBDM geospatial mapping and analysis](https://doi.org/10.5281/zenodo.13254494)