### PR TITLE
v.in.ascii: update parameter fs to separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # casas-gis
 
 - The functionality is already in a Bash (GRASS, <https://grass.osgeo.org/>) GIS script.
-- This is how to start turning it into a Python app <https://grass.osgeo.org/grass79/manuals/libpython/script_intro.html>
+- This is how to start turning it into a Python app <https://grass.osgeo.org/grass-stable/manuals/libpython/script_intro.html>
 - Converting Bash scripts to Python <https://grasswiki.osgeo.org/wiki/Converting_Bash_scripts_to_Python>
 - The script also calls some Perl scripts that do text manipulation (I think those should be relatively straightforward to turn into Python modules).
 - Should the Bash and Perl scripts included in the repo somehow as a reference
-- How to write a Python tool for GRASS <https://github.com/wenzeslaus/python-grass-addon>
+- How to write a Python addon tool for GRASS <https://github.com/wenzeslaus/python-grass-addon>
 
 ## Basic workflow of `gis_script.sh` is as follows
 

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -453,7 +453,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
     wait
 
     # Check for column type of parameter to map.

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -412,7 +412,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
     wait
 
     # Check for column type of parameter to map.

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -414,7 +414,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
     wait
 
     # Check for column type of parameter to map.

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -445,7 +445,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
     wait
 
     # Check for column type of parameter to map.

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -491,7 +491,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
 
     # Check for column type of parameter to map.
     if [ -n "$(v.info -c map=map$i | grep dbl_3)" ]; then

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -428,7 +428,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
     wait
     # Check for column type of parameter to map.
     if [ -n "$(v.info -c map=map$i | grep dbl_3)" ]; then

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -471,7 +471,7 @@ g.mapset mapset=medgold location=latlong_medgold
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
 
     # Check for column type of parameter to map.
     if [ -n "$(v.info -c map=map$i | grep dbl_3)" ]; then

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -461,7 +461,7 @@ g.mapset mapset=medgold location=latlong_medgold
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
 
     # Check for column type of parameter to map.
     if [ -n "$(v.info -c map=map$i | grep dbl_3)" ]; then

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -475,7 +475,7 @@ g.mapset mapset=luigi location=latlong
 cd $DIRTMP
 for i in $(ls); do
     echo "importing $i ..."
-    v.in.ascii input=$i output=map$i fs='\t' x=1 y=2 z=0
+    v.in.ascii input=$i output=map$i separator='\t' x=1 y=2 z=0
 
     # Check for column type of parameter to map.
     if [ -n "$(v.info -c map=map$i | grep dbl_3)" ]; then


### PR DESCRIPTION
Minor fixes:

- `v.in.ascii`: update parameter `fs` to `separator` for GRASS GIS 8 (removes warning)
- [README.md](https://github.com/casasglobal-org/casas-gis/blob/main/README.md): update URL to manual and wording cosmetics