### PR TITLE
GRASS GIS scripts: fix missing DIRTMP var and keyword format update

### DIFF
--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -36,8 +36,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map output of CASAS PBDMs for Mediterranean Basin (roughly where grape grows)
-# %  keywords: models
+# % description: Map output of CASAS PBDMs for Mediterranean Basin (roughly where grape grows)
+# % keywords: models
 # %End
 
 # %option
@@ -263,6 +263,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -22,8 +22,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map output of CASAS PBDMs for Libya and Tunisia
-# %  keywords: models
+# % description: Map output of CASAS PBDMs for Libya and Tunisia
+# % keywords: models
 # %End
 
 # %option
@@ -231,6 +231,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -24,8 +24,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map output of CASAS PBDMs for Mediterranean Basin
-# %  keywords: models
+# % description: Map output of CASAS PBDMs for Mediterranean Basin
+# % keywords: models
 # %End
 
 # %option
@@ -233,6 +233,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -28,8 +28,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map output of CASAS PBDMs for Africa
-# %  keywords: models
+# % description: Map output of CASAS PBDMs for Africa
+# % keywords: models
 # %End
 
 # %option
@@ -255,6 +255,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -23,8 +23,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map the output of CASAS models for India
-# %  keywords: models
+# % description: Map the output of CASAS models for India
+# % keywords: models
 # %End
 
 # %option
@@ -283,6 +283,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -23,8 +23,8 @@
 #############################################################################
 
 # %Module
-# %  description: Import and map the output of CASAS models for Italy
-# %  keywords: models
+# % description: Import and map the output of CASAS models for Italy
+# % keywords: models
 # %End
 
 # %option

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -41,8 +41,12 @@
 ############################################################################
 
 # %Module
-# %  description: Map and analyze the output of CASAS Global physiologically based demographic models (CASAS-PBDMs) for Andalusia provinces using GRASS GIS
-# %  keywords: MED-GOLD project, GRASS GIS, physiologically based demographic, models (PBDM), olive, agroecosystem analysis
+# % description: Map and analyze the output of CASAS Global physiologically based demographic models (CASAS-PBDMs) for Andalusia provinces using GRASS GIS
+# % keywords: MED-GOLD project
+# % keywords: GRASS GIS
+# % keywords: physiologically based demographic models (PBDM)
+# % keywords: olive
+# % keywords: agroecosystem analysis
 # %End
 
 # %option
@@ -277,6 +281,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -36,8 +36,12 @@
 ############################################################################
 
 # %Module
-# %  description: Map and analyze the output of CASAS Global physiologically based demographic models (CASAS-PBDMs) for Colombia departments using GRASS GIS
-# %  keywords: MED-GOLD project, GRASS GIS, physiologically based demographic, models (PBDM), coffee, agroecosystem analysis
+# % description: Map and analyze the output of CASAS Global physiologically based demographic models (CASAS-PBDMs) for Colombia departments using GRASS GIS
+# % keywords: MED-GOLD project
+# % keywords: GRASS GIS
+# % keywords: physiologically based demographic models (PBDM)
+# % keywords: coffee
+# % keywords: agroecosystem analysis
 # %End
 
 # %option
@@ -267,6 +271,9 @@ PERLSCRIPTS="${HOME}/PerlScripts"
 OUTFILES="${HOME}/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
+
+# Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
 
 # Directory with temporary files (see convert.pl script).
 

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -35,8 +35,8 @@
 #############################################################################
 
 # %Module
-# %  description: Map the output of CASAS models for the conterminous United States, Mexico, and Central America
-# %  keywords: models
+# % description: Map the output of CASAS models for the conterminous United States, Mexico, and Central America
+# % keywords: models
 # %End
 
 # %option


### PR DESCRIPTION
- add missing DIRTMP variable
- fix keyword format in parser section (multiple lines are needed in G8)