### PR TITLE
grass_scripts: further updates to GRASS GIS 8 and cross-sync

### DIFF
--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -6,32 +6,32 @@
 #
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
-# PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+# PURPOSE:      Import ASCII output files from CASAS models
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
-#                       Voronoi part was reimplemented as in Mediterraneo
-#                       and flag -s removed because no longer used.
+#               type "Olive_02Mar06_00003.txt".
+#               Voronoi part was reimplemented as in Mediterraneo
+#               and flag -s removed because no longer used.
 #
-#				Updates:
-#				2017-05-22 Added ability to zoom to a subset of countries,
-#						either with or without clipping to grape growing
-#						region.
-#				2019-08-30 Added ability to use grape or tomato (various)
-#						for clipping model output as a multiple choice
-#						option. Works for entire region or subset of
-#						countries.
-#				2022-11-11 Added ability to save raster output as GeoTIFF.
-#				2025-01-21 Added alflafa harvested area to the list of
-#                       crops for clipping model output.
+#               Updates:
+#               2017-05-22 Added ability to zoom to a subset of countries,
+#                          either with or without clipping to grape growing
+#                          region.
+#               2019-08-30 Added ability to use grape or tomato (various)
+#                          for clipping model output as a multiple choice
+#                          option. Works for entire region or subset of
+#                          countries.
+#               2022-11-11 Added ability to save raster output as GeoTIFF.
+#               2025-01-21 Added alflafa harvested area to the list of
+#                          crops for clipping model output.
 #
 # Copyright:    (c) 2005-2025 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems
-#                       https://www.casasglobal.org/).
+#               of Sustainable Agricultural Systems
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -259,10 +259,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -977,15 +977,14 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw
-        predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
     done
 fi
 
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -977,7 +977,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt="COMPRESS=LZW,PREDICTOR=3,BIGTIFF=YES"
     done
 fi
 

--- a/casas_gis_old/casas/grass_scripts/EurMedGrape
+++ b/casas_gis_old/casas/grass_scripts/EurMedGrape
@@ -33,7 +33,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map output of CASAS PBDMs for Mediterranean Basin (roughly where grape grows)
@@ -206,7 +206,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -259,15 +259,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -288,10 +288,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=AEA_Med
+    g.mapset mapset=luigi project=AEA_Med
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=raster,vector pattern="map*"
     g.remove -f type=raster pattern="model*"
@@ -309,7 +309,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -423,7 +423,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -450,7 +449,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -469,7 +468,7 @@ done
 wait
 
 # Change to GRASS location where MED maps are.
-g.mapset mapset=luigi location=AEA_Med
+g.mapset mapset=luigi project=AEA_Med
 
 # Define the extent of the map and its grid resolution (currently 3 km).
 g.region -a vect=admin0_10m_naturalEarth_MED res=3000
@@ -542,28 +541,31 @@ echo "This log reports names of input files and full command used for analysis.
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Start interpolation process.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-# export GRASS_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
 
-# d.erase color=white
+# d.erase
 mapcycle=1
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -629,7 +631,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolRaw$i sie=46000 sin=46000 method=bicubic lambda_i=0.01 layer=1 column=$varType
 
         # Constrain interpolated raster within max-min from vector input
@@ -656,7 +658,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -733,12 +736,12 @@ for i in $(ls); do
                 fi
             fi
         fi
-        # Overalay model raster to a shaded relief and add state
+        # Overlay model raster to a shaded relief and add state
         # boundaries, weather stations, etc.
         # r.neighbors 21x21 window with circular neighborood (i.e. -c flag) on the original DEM.
         # Then the output DEM was cropped via r.mapcalc
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
-        # r.shaded.releif 67/270/10 - done following an idea
+        # r.shaded.relief 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
         # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
@@ -762,7 +765,7 @@ for i in $(ls); do
         d.legend -s map=MskdModPOS$i color=black lines=0 thin=1000 labelnum=5 at=6,9,15,85 # range=34.02170,2717.63107 # exclude outliers.
         # legend range relative to current map. Old horizontal legend location 10,13.5,10,90
 
-        # To excluede outliers from legend, the range=min,max option in d.legend
+        # To exclude outliers from legend, the range=min,max option in d.legend
         # needs to be enabled in the GIS script MedPresentClimate using
         # the two whiskers of the R box plot (see boxplot.stats() in R).
 
@@ -770,7 +773,7 @@ for i in $(ls); do
     # It is possible to implement user-defined categories
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
-    # Display true type font text in the legend (at x-y, coordinates).
+    # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
 
     Legend1="$(cat ${OUTFILES}/legend1.txt)"
@@ -782,7 +785,8 @@ for i in $(ls); do
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
     # d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/"$i" res=$FIGRES format=eps
-    d.mon stop=PNG
+    # Save display to .png file.
+    d.mon stop=png
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
@@ -838,14 +842,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy.
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -880,7 +885,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.rast map=MSR_50M_land
     d.vect map=admin0_10m_naturalEarth_MED type=boundary width=3
@@ -894,14 +900,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    d.barscale at=50,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.his i=MSR_50M_land h=natural_earth_color.composite
     #~ d.vect map=waterareas type=boundary,area \
@@ -917,8 +924,8 @@ else
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    d.barscale at=50,7
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -935,7 +942,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
@@ -979,5 +986,6 @@ fi
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -19,7 +19,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map output of CASAS PBDMs for Libya and Tunisia
@@ -174,7 +174,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -227,15 +227,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -256,10 +256,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=libya location=AEA_Med
+    g.mapset mapset=libya project=AEA_Med
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=raster,vector pattern="map*"
     g.remove -f type=raster pattern="model*"
@@ -277,7 +277,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -382,7 +382,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -409,7 +408,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -428,7 +427,7 @@ done
 wait
 
 # Change to GRASS location where MED maps are.
-g.mapset mapset=libya location=AEA_Med
+g.mapset mapset=libya project=AEA_Med
 
 # Define the extent of the map and its grid resolution (currently 3 km).
 g.region -a n=-3000 s=-2040000 w=-726000 e=1116000 res=3000
@@ -445,27 +444,31 @@ r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Start interpolation process.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows + 260) * FIGRES))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 260  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
 
-# d.erase color=white
+# d.erase
 n=1
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -529,7 +532,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i sie=69780 sin=69780 method=bicubic lambda_i=0.05 layer=1 column=$varType
         r.mapcalc "interpol$i = if(ElevAltMask, interpolNoMask$i, null())"
     fi
@@ -548,7 +551,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # If flag -g is checked, output is a greyscale figure
     if [ "$GIS_FLAG_G" -eq 1 ]; then
@@ -621,12 +625,12 @@ for i in $(ls); do
                 fi
             fi
         fi
-        # Overalay model raster to a shaded relief and add state
+        # Overlay model raster to a shaded relief and add state
         # boundaries, weather stations, etc.
         # r.neighbors 21x21 window with circular neighborood (i.e. -c flag) on the original DEM.
         # Then the output DEM was cropped via r.mapcalc
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
-        # r.shaded.releif 67/270/10 - done following an idea
+        # r.shaded.relief 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
         # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
@@ -660,7 +664,7 @@ for i in $(ls); do
         d.legend -s map=MskdModPOS$i color=black lines=0 thin=1000 labelnum=5 at=6,11,20,80 # range=-0.440,0.574 # exclude outliers.
         # legend range relative to current map. Old horizontal legend location 10,13.5,10,90
 
-        # To excluede outliers from legend, the range=min,max option in d.legend
+        # To exclude outliers from legend, the range=min,max option in d.legend
         # needs to be enabled in the GIS script MedPresentClimate using
         # the two whiskers of the R box plot (see boxplot.stats() in R).
 
@@ -668,7 +672,10 @@ for i in $(ls); do
     # It is possible to implement user-defined categories
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
-    # Display true type font text in the legend (at x-y, coordinates).
+    # Display scale bar.
+    # d.barscale at=50,7
+
+    # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
 
     Legend1="$(cat ${OUTFILES}/legend1.txt)"
@@ -680,7 +687,8 @@ for i in $(ls); do
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
     # d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/"$i" res=$FIGRES format=eps
-    d.mon stop=PNG
+    # Save display to .png file.
+    d.mon stop=png
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"$LEG1".log
 
@@ -688,7 +696,7 @@ for i in $(ls); do
     # Raster statistics here  #    # Maybe do a test mapping cycle beforehand.
     ##############
 
-    # Raster statistics based on vector areas; histrogram by vector areas; what else?
+    # Raster statistics based on vector areas; histogram by vector areas; what else?
 
     # If flag -r is checked, then write raster statistics.
     if [ "$GIS_FLAG_R" -eq 1 ]; then
@@ -716,14 +724,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -743,7 +752,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.rast map=libya_tunisia_shaded_relief
     d.vect map=libya_tunisia_boundaries type=boundary width=2
@@ -757,14 +767,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     d.grid -w size=4:0:0 origin=0,0 color=gray bordercolor=black textcolor=black fontsize=15
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    d.barscale at=50,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Natural Earth composite not available at this time
     # Available on request.
@@ -774,9 +785,11 @@ else
     d.grid -w size=4:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
+
     # d.mon stop=x0
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    # Display scale bar.
+    d.barscale at=50,7
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -793,7 +806,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -828,5 +841,6 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/LibyaTunisia
+++ b/casas_gis_old/casas/grass_scripts/LibyaTunisia
@@ -7,17 +7,17 @@
 # AUTHOR(S):    Luigi Ponti lponti inbox com
 #
 # PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
+#               type "Olive_02Mar06_00003.txt".
 #
-# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems).
-#                       https://www.casasglobal.org/).
+# Copyright:    (c) 2005-2012 CASAS Global (Center for the Analysis
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -227,10 +227,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -840,7 +840,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -21,7 +21,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map output of CASAS PBDMs for Mediterranean Basin
@@ -176,7 +176,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -229,15 +229,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -258,10 +258,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=AEA_Med
+    g.mapset mapset=luigi project=AEA_Med
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=raster,vector pattern="map*"
     g.remove -f type=raster pattern="model*"
@@ -279,7 +279,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=x0
+    d.mon stop=png
     exit 1
 }
 
@@ -384,7 +384,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -411,7 +410,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -430,7 +429,7 @@ done
 wait
 
 # Change to GRASS location where MED maps are.
-g.mapset mapset=luigi location=AEA_Med
+g.mapset mapset=luigi project=AEA_Med
 
 # Define the extent of the map and its grid resolution (currently 3 km).
 g.region -a n=900000 s=-930000 e=2050000 w=-2343000 res=3000
@@ -469,27 +468,31 @@ fi
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Start interpolation process.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows + 260) * FIGRES))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 260  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
 
-# d.erase color=white
+# d.erase
 n=1
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
     wait
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
@@ -556,7 +559,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=3 layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i sie=69780 sin=69780 method=bicubic lambda_i=0.05 layer=1 column=$varType
         r.mapcalc "interpol$i = if(ElevAltMask, interpolNoMask$i, null())"
     fi
@@ -575,7 +578,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -652,12 +656,12 @@ for i in $(ls); do
                 fi
             fi
         fi
-        # Overalay model raster to a shaded relief and add state
+        # Overlay model raster to a shaded relief and add state
         # boundaries, weather stations, etc.
         # r.neighbors 21x21 window with circular neighborood (i.e. -c flag) on the original DEM.
         # Then the output DEM was cropped via r.mapcalc
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
-        # r.shaded.releif 67/270/10 - done following an idea
+        # r.shaded.relief 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
         # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
@@ -689,7 +693,10 @@ for i in $(ls); do
     # It is possible to implement user-defined categories
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
-    # Display true type font text in the legend (at x-y, coordinates).
+    # Display scale bar.
+    # d.barscale at=50,7
+
+    # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
 
     Legend1="$(cat ${OUTFILES}/legend1.txt)"
@@ -701,7 +708,8 @@ for i in $(ls); do
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
     # d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/"$i" res=$FIGRES format=eps
-    d.mon stop=PNG
+    # Save display to .png file.
+    d.mon stop=png
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
@@ -737,14 +745,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy.
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -764,7 +773,7 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.erase
 
     d.rast map=era40_67_270_10_grow
     d.vect map=admin0_10m_naturalEarth_MED type=boundary width=2
@@ -779,14 +788,14 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    d.barscale at=50,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.erase
 
     d.his i=era40_67_270_10_grow h=natural_earth_color.composite
     #~ d.vect map=waterareas type=boundary,area \
@@ -803,8 +812,9 @@ else
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    # Display scale bar.
+    d.barscale at=50,7
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -821,7 +831,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}${LEG2}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}${LEG2}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -856,5 +866,6 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/MedPresentClimate
+++ b/casas_gis_old/casas/grass_scripts/MedPresentClimate
@@ -6,20 +6,20 @@
 #
 # AUTHOR(S):    Luigi Ponti lponti inbox com
 #
-# PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+# PURPOSE:      Import ASCII output files from CASAS models
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
-#                       Voronoi part was reimplemented as in Mediterraneo
-#                       and flag -s removed because no longer used.
+#               type "Olive_02Mar06_00003.txt".
+#               Voronoi part was reimplemented as in Mediterraneo
+#               and flag -s removed because no longer used.
 #
-# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems).
-#                       https://www.casasglobal.org/).
+# Copyright:    (c) 2005-2012 CASAS Global (Center for the Analysis
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -229,10 +229,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -685,7 +685,7 @@ for i in $(ls); do
         d.legend -s map=MskdModPOS$i color=black lines=0 thin=1000 labelnum=5 at=6,11,20,80 # range=34.02170,2717.63107 # exclude outliers.
         # legend range relative to current map. Old horizontal legend location 10,13.5,10,90
 
-        # To excluede outliers from legend, the range=min,max option in d.legend
+        # To exclude outliers from legend, the range=min,max option in d.legend
         # needs to be enabled in the GIS script MedPresentClimate using
         # the two whiskers of the R box plot (see boxplot.stats() in R).
 
@@ -771,7 +771,7 @@ echo "($(date -R | tr -s ' ' ' '))" | tee -a "$SaveDir"/"${LEG1}${LEG2}".log
 # If flag -g is checked, output is a greyscale figure (no lakes)
 if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
-    GRASS_PNGFILE="$SaveDir"/WeatherStations.png
+    GRASS_PNGFILE="$SaveDir/WeatherStations.png"
     export GRASS_PNGFILE
     d.erase
 
@@ -865,7 +865,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -975,15 +975,14 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw
-        predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
     done
 fi
 
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -25,7 +25,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map output of CASAS PBDMs for Africa
@@ -198,7 +198,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -251,15 +251,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -280,10 +280,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=africa_aea
+    g.mapset mapset=luigi project=africa_aea
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=raster,vector pattern="map*"
     g.remove -f type=raster pattern="model*"
@@ -301,7 +301,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -415,7 +415,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -442,7 +441,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -461,7 +460,7 @@ done
 wait
 
 # Change to GRASS location where MED maps are.
-g.mapset mapset=luigi location=africa_aea
+g.mapset mapset=luigi project=africa_aea
 
 # Define the extent of the map and its grid resolution (currently 3 km).
 
@@ -518,28 +517,31 @@ echo "This log reports names of input files and full command used for analysis.
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
 # Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Start interpolation process.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-# export GRASS_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
 
-# d.erase color=white
+# d.erase
 mapcycle=1
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -605,7 +607,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolRaw$i sie=46000 sin=46000 method=bicubic lambda_i=0.01 layer=1 column=$varType
 
         # Constrain interpolated raster within max-min from vector input
@@ -632,7 +634,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -713,12 +716,12 @@ for i in $(ls); do
                 fi
             fi
         fi
-        # Overalay model raster to a shaded relief and add state
+        # Overlay model raster to a shaded relief and add state
         # boundaries, weather stations, etc.
         # r.neighbors 21x21 window with circular neighborood (i.e. -c flag) on the original DEM.
         # Then the output DEM was cropped via r.mapcalc
         # newShade = "if(OriginalDem, OldShade, null())". The shaded relief
-        # r.shaded.releif 67/270/10 - done following an idea
+        # r.shaded.relief 67/270/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
         # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
@@ -746,7 +749,7 @@ for i in $(ls); do
         d.legend -s map=MskdModPOS$i color=black lines=0 thin=1000 labelnum=5 at=6,9,15,85 # range=34.02170,2717.63107 # exclude outliers.
         # legend range relative to current map. Old horizontal legend location 10,13.5,10,90
 
-        # To excluede outliers from legend, the range=min,max option in d.legend
+        # To exclude outliers from legend, the range=min,max option in d.legend
         # needs to be enabled in the GIS script MedPresentClimate using
         # the two whiskers of the R box plot (see boxplot.stats() in R).
 
@@ -754,7 +757,10 @@ for i in $(ls); do
     # It is possible to implement user-defined categories
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
-    # Display true type font text in the legend (at x-y, coordinates).
+    # Display scale bar.
+    # d.barscale at=50,7
+
+    # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
 
     Legend1="$(cat ${OUTFILES}/legend1.txt)"
@@ -766,7 +772,8 @@ for i in $(ls); do
     # Save display to .png file (increasing resolution (res) = 1, 2, or 4)
     # d.out.file output="$SaveDir"/"$i" res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/"$i" res=$FIGRES format=eps
-    d.mon stop=PNG
+    # Save display to .png file.
+    d.mon stop=png
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
 
@@ -822,14 +829,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy.
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -868,7 +876,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.rast map=MSR_50M
     d.vect map=coastline_africa type=line,boundary color=150:150:150 width=2
@@ -884,13 +893,14 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
     d.barscale at=7,93
-    d.mon stop=PNG
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.his i=MSR_50M h=natural_earth_color.composite
     d.vect map=ne_50m_lakes_africa type=boundary,area color=150:150:150 fcolor=215:240:255
@@ -905,9 +915,12 @@ else
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
+
     # d.mon stop=x0
-    d.barscale -s at=7,93
-    d.mon stop=PNG
+    # Display scale bar.
+    d.barscale at=7,93
+
+    d.mon stop=png
 fi
 
 # Land mask is required in Africa as raster layers are not clipped
@@ -927,7 +940,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
@@ -971,5 +984,6 @@ fi
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -6,24 +6,24 @@
 #
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
-# PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+# PURPOSE:      Import ASCII output files from CASAS models
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
-#                       Voronoi part was reimplemented as in Mediterraneo
-#                       and flag -s removed because no longer used.
+#               type "Olive_02Mar06_00003.txt".
+#               Voronoi part was reimplemented as in Mediterraneo
+#               and flag -s removed because no longer used.
 #
-#				Updates:
-#				2022-11-24 (first release)
+#               Updates:
+#               2022-11-24 (first release)
 #               2024-07-26 Ability to clip for cassava crop area
 #
 # Copyright:    (c) 2005-2024 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems).
-#                       https://www.casasglobal.org/).
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -251,10 +251,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"

--- a/casas_gis_old/casas/grass_scripts/africa
+++ b/casas_gis_old/casas/grass_scripts/africa
@@ -975,7 +975,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt="COMPRESS=LZW,PREDICTOR=3,BIGTIFF=YES"
     done
 fi
 

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -20,7 +20,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map the output of CASAS models for India
@@ -279,15 +279,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -308,10 +308,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=LAEA_India
+    g.mapset mapset=luigi project=LAEA_India
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=vector pattern="selectedStates"
     g.remove -f type=vector pattern="Eto*"
@@ -332,7 +332,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -461,7 +461,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -488,7 +487,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -505,7 +504,7 @@ for i in $(ls); do
 done
 
 # Change to GRASS location where US maps are.
-g.mapset mapset=luigi location=LAEA_India
+g.mapset mapset=luigi project=LAEA_India
 
 # Transform dummy value for conterminous US.
 if [ "$STATES" = 'India' ]; then
@@ -562,26 +561,31 @@ echo "This log reports names of input files and full command used for analysis.
 
 Input file names:" | tee -a "$SaveDir"/"${LEG1}".log
 
-# Retrieve range min and max values for possible use in legend drawing. Maybe check if the files exists...
+# Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Set size of output image.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
+
 n=1 # this is just a counter
 # Start interpolation process.
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -646,7 +650,7 @@ for i in $(ls); do
         v.surf.idw -n input=mapPos$i output=interpol$i layer=1 \
             col=$varType npoints=$PNTS power=$IDW_POW
     else
-        # http://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolNoMask$i \
             sie=$EAST_STEP sin=$NORTH_STEP method=bicubic \
             lambda_i=$TYKHONOV layer=1 column=$varType
@@ -667,7 +671,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -785,7 +790,7 @@ for i in $(ls); do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display scale bar.
-    # d.barscale -l at=50,7
+    # d.barscale at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
@@ -797,7 +802,7 @@ for i in $(ls); do
     d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$n.txt
 
     # Save display to .png file.
-    d.mon stop=PNG
+    d.mon stop=png
 
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
@@ -876,14 +881,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -895,6 +901,7 @@ for i in $(ls); do
 done
 
 # Write full command line to log.
+echo "GIS script syntax used:
 
 # Use g.parser -s to send so the options and flags are written to stdout, hence e.g.
 #
@@ -938,21 +945,22 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     d.rast map=india_shaded_60_315_10
     d.vect map=india_region_world_bounds type=boundary color=150:150:150 width=2
     d.vect map=india_states type=boundary width=4
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=15
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    d.barscale -s at=50,7
-    d.mon stop=PNG
+    d.barscale at=50,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.erase
     r.mapcalc 'selectedStates.composite = if(selectedStatesRaster, natural_earth_color.composite, null())'
     r.colors map=selectedStates.composite raster=natural_earth_color.composite
     d.his i=india_shaded_60_315_10 h=selectedStates.composite
@@ -965,9 +973,9 @@ else
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
 
     # Display scale bar.
-    # d.barscale -l at=50,7
+    # d.barscale at=50,7
 
-    d.mon stop=PNG
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -984,7 +992,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -1012,9 +1020,14 @@ fi
 mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
+
+# Perform final cleanup.
+#~ cleanup
+
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/india
+++ b/casas_gis_old/casas/grass_scripts/india
@@ -7,18 +7,18 @@
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
 # PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Cotton_02Mar06_00003.txt".
+#               type "Cotton_02Mar06_00003.txt".
 #
 #
-# Copyright:    (c) 2005-2013 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems).
-#                       https://www.casasglobal.org/).
+# Copyright:    (c) 2005-2013 CASAS Global (Center for the Analysis
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -279,10 +279,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -1027,7 +1027,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -20,7 +20,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Import and map the output of CASAS models for Italy
@@ -184,7 +184,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -237,17 +237,19 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
+# export GRASS_OVERWRITE=1
+
 # export GRASS_VERBOSE=1
 
-# Cleanup in case of error.
+# Cleanup routine.
 cleanup() {
     # Remove temp directory.
     \rm -rf $DIRTMP
@@ -263,10 +265,10 @@ cleanup() {
     \rm -f ${OUTFILES}/min.txt
     \rm -f ${OUTFILES}/max.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=luigi location=EurLCC
+    g.mapset mapset=luigi project=EurLCC
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=raster,vector pattern="map*"
     g.remove -f type=raster pattern="model*"
@@ -422,7 +424,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -440,7 +442,7 @@ done
 wait
 
 # Change to GRASS location where Italy maps are.
-g.mapset mapset=luigi location=EurLCC
+g.mapset mapset=luigi project=EurLCC
 
 # Define the extent of the map and its grid resolution (currently 1 km).
 g.region res=1000
@@ -471,25 +473,30 @@ r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
 # Write header in the log file.
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"$LEG".log
 # Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Set size of output image.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
 # Choose a font for figure text.
 export GRASS_FONT='arial'
+
 mapcycle=1 # this is just a counter
 # Start interpolation process.
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation double precision"
@@ -548,7 +555,7 @@ for i in $(ls); do
     v.to.rast input=voronoiSel output=MskdBuffer$i use=val value=1
     wait
 
-    # Set a proper MASK to speed up interpolation process.
+    # Set mask for interpolation.
     g.copy raster=ElevAltMask,MASK
 
     if [ $SURF == "idw" ]; then
@@ -557,7 +564,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolRaw$i sie=46000 sin=46000 method=bicubic lambda_i=0.01 layer=1 column=$varType
 
         # Constrain interpolated raster within max-min from vector input
@@ -588,7 +595,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # If flag -g is checked, output is a greyscale figure
     if [ "$GIS_FLAG_g" -eq 1 ]; then
@@ -694,6 +702,9 @@ for i in $(ls); do
     # It is possible to implement user-defined categories
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
+    # Display scale bar.
+    # d.barscale at=50,7
+
     # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo $LEG > ${OUTFILES}/legend.txt
 
@@ -705,7 +716,7 @@ for i in $(ls); do
     d.text size=3 color=black at=5,94 input=${OUTFILES}/legend$mapcycle.txt
 
     # Save display to .png file.
-    d.mon stop=PNG
+    d.mon stop=png
 
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"$LEG".log
@@ -751,14 +762,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy.
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -794,7 +806,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     d.rast map=60_310_4
     d.vect map=italia width=2
@@ -804,14 +817,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
     # d.mon stop=x0
-    d.barscale -s at=2,90 fontsize=25
-    d.mon stop=PNG
+    d.barscale at=2,90 fontsize=25
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
-    # If flag -g is not checked, output is a color figure (with lakes)
+    # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     d.rast map=60_310_4
     # r.colors map=laghi rules=aqua;
     d.rast -o map=laghi
@@ -823,10 +837,12 @@ else
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=25
     # d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    # d.mon stop=x0
-    d.barscale -s at=2,90 fontsize=25
 
-    d.mon stop=PNG
+    # d.mon stop=x0
+    # Display scale bar.
+    d.barscale at=2,90 fontsize=25
+
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -843,7 +859,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "$LEG" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "$LEG" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$REG" "$Plots"
 
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
@@ -878,6 +894,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/$LEG.html"
+firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/italia
+++ b/casas_gis_old/casas/grass_scripts/italia
@@ -7,18 +7,18 @@
 # AUTHOR(S):    Luigi Ponti lponti inbox com
 #
 # PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
+#               type "Olive_02Mar06_00003.txt".
 #
 #
-# Copyright:    (c) 2005-2012 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems).
-#                       https://www.casasglobal.org/).
+# Copyright:    (c) 2005-2012 CASAS Global (Center for the Analysis
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -286,7 +286,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=x0
+    d.mon stop=png
     exit 1
 }
 
@@ -396,7 +396,6 @@ perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 wait
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convertITA.pl "$HOME"
 wait
 
@@ -724,21 +723,21 @@ for i in $(ls); do
     # If flag -r is checked, then write raster statistics.
     if [ "$GIS_FLAG_R" -eq 1 ]; then
         r.report -en map=regioni_istat,MskdModPOS$i units=k,p nsteps=4 | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Raster univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Vector univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Raster univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        r.univar map=MskdModPOS$i | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Vector univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
         wait
         if [ "$mapcycle" -eq 1 ]; then
             echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -757,7 +756,7 @@ for i in $(ls); do
                 Plots=0
             fi
         fi
-        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir"/$i.txt
+        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir/$i.txt"
     fi
 
     # If flag -p is checked, then write .rep report files to be plotted.
@@ -765,7 +764,7 @@ for i in $(ls); do
         # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
-        GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
+        GRASS_PNGFILE="$SaveDir/$i-HIST.png"
         export GRASS_PNGFILE
         d.mon start=png
         d.erase
@@ -786,7 +785,7 @@ cat >> "$SaveDir"/"${LEG}".log << EOF
 
 GIS script syntax used:
 
-    EurMedGrape
+    italia
     w=$GIS_FLAG_W g=$GIS_FLAG_G e=$GIS_FLAG_E l=$GIS_FLAG_L
     x=$GIS_FLAG_X a=$GIS_FLAG_A d=$GIS_FLAG_D u=$GIS_FLAG_U
     c=$GIS_FLAG_C r=$GIS_FLAG_R p=$GIS_FLAG_P m=$GIS_FLAG_M
@@ -798,7 +797,7 @@ GIS script syntax used:
 EOF
 
 # Write date in the log file.
-echo "($(date -R | tr -s ' ' ' '))" | tee -a "$SaveDir"/"${LEG}".log
+echo "($(date -R | tr -s ' ' ' '))" | tee -a "$SaveDir/${LEG1}.log"
 
 # Display & save a map with weather stations used for analysis.
 # If flag -g is checked, output is a greyscale figure (no lakes)
@@ -894,7 +893,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -277,15 +277,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -306,10 +306,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=medgold location=latlong_medgold
+    g.mapset mapset=medgold project=latlong_medgold
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=medgold location=laea_andalusia
+    g.mapset mapset=medgold project=laea_andalusia
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=vector pattern="selectedStates"
     g.remove -f type=raster,vector pattern="map*"
@@ -329,7 +329,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -472,7 +472,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=medgold location=latlong_medgold
+g.mapset mapset=medgold project=latlong_medgold
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -489,7 +489,7 @@ for i in $(ls); do
 done
 
 # Change to GRASS location where projected maps are.
-g.mapset mapset=medgold location=laea_andalusia
+g.mapset mapset=medgold project=laea_andalusia
 
 # Selection of based on vector areas.
 if [ "$PROVINCES" = 'all' ]; then
@@ -547,19 +547,24 @@ abs_max=$(cat ${OUTFILES}/max.txt)
 # Set size of output image.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
+
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
+
 mapcycle=1 # this is just a counter
 # Start interpolation process.
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong_medgold mapset=medgold output=map$i
+    v.proj input=map$i project=latlong_medgold mapset=medgold output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -650,7 +655,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -761,7 +767,7 @@ for i in $(ls); do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display scale bar.
-    # d.barscale -l at=50,7
+    # d.barscale at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
@@ -773,7 +779,7 @@ for i in $(ls); do
     d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
-    d.mon stop=PNG
+    d.mon stop=png
 
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"$LEG1".log
@@ -825,14 +831,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy -- TO BE IMPLEMENTED IN R
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -866,7 +873,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     d.rast map=GRAY_HR_SR_OB_DR_andalusia_250m
     d.vect map=ne_10m_coastline_andalusia type=boundary color=150:150:150 width=3
     d.vect map=ne_10m_admin_0_countries_lakes_andalusia type=boundary color=128:128:128 width=3
@@ -876,14 +884,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     d.grid -w size=1:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=15
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    d.barscale -s at=7,7
-    d.mon stop=PNG
+    d.barscale at=7,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     r.mapcalc 'selectedStates.composite = if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_andalusia_250m, null())'
     r.colors map=selectedStates.composite raster=NE1_HR_LC_SR_W_DR.composite_andalusia_250m
     d.his i=SR_HR_andalusia_clip_250m h=selectedStates.composite brighten=5
@@ -897,8 +906,8 @@ else
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
 
     # Display scale bar.
-    d.barscale -s at=7,7
-    d.mon stop=PNG
+    d.barscale at=7,7
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -915,7 +924,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -943,6 +952,9 @@ fi
 mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
+# Perform final cleanup.
+#~ cleanup
+
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
@@ -955,5 +967,6 @@ fi
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -958,7 +958,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt="COMPRESS=LZW,PREDICTOR=3,BIGTIFF=YES"
     done
 fi
 

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -6,37 +6,37 @@
 #
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
-# PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+# PURPOSE:      Import ASCII output files from CASAS models
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
+#               type "Olive_02Mar06_00003.txt".
 #
-#				Updates:
-#				2017-05-22 Added ability to zoom to a subset of countries
-#                       (or e.g., provinces), either with or without clipping
-#                       to crop growing extent.
-#				2019-08-30 Added ability to use tomato (or other crops)
-#						for clipping model output as a multiple choice
-#						option. Works for entire region or subset of
-#						countries.
-#				2019-09-28 Added ability to modify extent of crop growing
-#						area used for clipping model output based on a
-#						threshold for crop harvested area fraction above
-#                       which mapping will occur. Works for entire region
-#                       or subset of countries.
-#				2021-04-14 Added ability to map area of olive monocolture
-#						from SIGPAC 2018 database by Junta de Andalucia
-#				2021-04-19 Added ability to perform statistics on SIGPAC 2018
-#						original area and to save raster output as GeoTIFF
+#               Updates:
+#               2017-05-22 Added ability to zoom to a subset of countries
+#                          (or e.g., provinces), either with or without clipping
+#                          to crop growing extent.
+#               2019-08-30 Added ability to use tomato (or other crops)
+#                          for clipping model output as a multiple choice
+#                          option. Works for entire region or subset of
+#                          countries.
+#               2019-09-28 Added ability to modify extent of crop growing
+#                          area used for clipping model output based on a
+#                          threshold for crop harvested area fraction above
+#                          which mapping will occur. Works for entire region
+#                          or subset of countries.
+#               2021-04-14 Added ability to map area of olive monocolture
+#                          from SIGPAC 2018 database by Junta de Andalucia
+#               2021-04-19 Added ability to perform statistics on SIGPAC 2018
+#                          original area and to save raster output as GeoTIFF
 
 #
 # Copyright:    (c) 2005-2021 CASAS Global (Center for the Analysis
-#                       of Sustainable Agricultural Systems Global
-#                       https://www.casasglobal.org/).
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -277,10 +277,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -537,7 +537,7 @@ elif [ "$CROP" == "none" ]; then
 fi
 
 # Write header in the log file.
-echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
+echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir/${LEG1}.log"
 
 # Retrieve range min and max values for possible use in legend drawing.
 # Maybe check if the files exists...
@@ -788,26 +788,26 @@ for i in $(ls); do
     # If flag -r is checked, then write raster statistics.
     if [ "$GIS_FLAG_R" -eq 1 ]; then
         r.mapcalc MskdModPOS_sigpac$i = "if (olive_monoculture_sigpac_2018 == 1, MskdModPOS$i, null())"
-        echo "Raster statistics by province:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
+        echo "Raster statistics by province:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
         # need to implement this by developing a raster with state categories
         # currently only works on output raster using 4 steps
-        r.report -en map=andalusia_provinces,MskdModPOS_sigpac$i units=k,c,p nsteps=4 | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Raster univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Vector univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
+        r.report -en map=andalusia_provinces,MskdModPOS_sigpac$i units=k,c,p nsteps=4 | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Raster univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        r.univar map=MskdModPOS$i | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Vector univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
         wait
         if [ "$mapcycle" -eq 1 ]; then
             echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -826,7 +826,7 @@ for i in $(ls); do
                 Plots=0
             fi
         fi
-        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir"/$i.txt
+        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir/$i.txt"
     fi
 
     # If flag -p is checked, then write .rep report files to be plotted.
@@ -834,7 +834,7 @@ for i in $(ls); do
         # Not working for now since G6 r.stats is buggy -- TO BE IMPLEMENTED IN R
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
-        GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
+        GRASS_PNGFILE="$SaveDir/$i-HIST.png"
         export GRASS_PNGFILE
         d.mon start=png
         d.erase
@@ -861,17 +861,17 @@ echo "GIS script syntax used:
 	parameter=$PAR interpolation=$SURF numpoints=$PNTS
 	lowercut=$CUT uppercut=$HICUT legend1=$LEG1 provinces=$PROVINCES
 	alt=$ALT resolution=$FIGRES lowBarCol=$LOWBARCOL upBarCol=$UPBARCOL
-	crop=$CROP crop_threshold=$CROP_THRESHOLD" | tee -a "$SaveDir"/"${LEG1}".log
+	crop=$CROP crop_threshold=$CROP_THRESHOLD" | tee -a "$SaveDir/${LEG1}.log"
 
 # Write date in the log file.
-echo "($(date -R | tr -s ' ' ' '))" | tee -a "$SaveDir"/"${LEG1}".log
+echo "($(date -R | tr -s ' ' ' '))" | tee -a "$SaveDir/${LEG1}.log"
 
 # Display & save a map with weather stations used for analysis
 # or simply a map with major geographic features of the area.
 # If flag -g is checked, output is a greyscale figure (no lakes)
 if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
-    GRASS_PNGFILE="$SaveDir"/WeatherStations.png
+    GRASS_PNGFILE="$SaveDir/WeatherStations.png"
     export GRASS_PNGFILE
     d.mon start=png
     d.erase
@@ -889,7 +889,7 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
-    GRASS_PNGFILE="$SaveDir"/WeatherStations.png
+    GRASS_PNGFILE="$SaveDir/WeatherStations.png"
     export GRASS_PNGFILE
     d.mon start=png
     d.erase
@@ -958,15 +958,14 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Save various raster output files to GeoTIFF
 if [ "$GIS_FLAG_T" -eq 1 ]; then
     for raster_outfile in $(g.list raster pattern="MskdModPOS*"); do
-        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw
-        predictor=3
+        r.out.gdal input=$raster_outfile output=${OUTFILES}/$GIS_OPT_SAVEDIR/data/${raster_outfile}.tif format=GTiff createopt=compress=lzw predictor=3
     done
 fi
 
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.andalusia
@@ -831,7 +831,7 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since G6 r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir/$i-HIST.png"

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -7,31 +7,31 @@
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
 # PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
+#               type "Olive_02Mar06_00003.txt".
 #
-#				Updates:
-#				2017-05-22 Added ability to zoom to a subset of countries
-#                       (or e.g., provinces), either with or without clipping
-#                       to crop growing extent.
-#				2019-08-30 Added ability to use tomato (or other crops)
-#						for clipping model output as a multiple choice
-#						option. Works for entire region or subset of
-#						countries.
-#				2019-09-28 Added ability to modify extent of crop growing
-#						area used for clipping model output based on a
-#						threshold for crop harvested area fraction above
-#                       which mapping will occur. Works for entire region
-#                       or subset of countries.
+#               Updates:
+#               2017-05-22 Added ability to zoom to a subset of countries
+#                          (or e.g., provinces), either with or without clipping
+#                          to crop growing extent.
+#               2019-08-30 Added ability to use tomato (or other crops)
+#                          for clipping model output as a multiple choice
+#                          option. Works for entire region or subset of
+#                          countries.
+#               2019-09-28 Added ability to modify extent of crop growing
+#                          area used for clipping model output based on a
+#                          threshold for crop harvested area fraction above
+#                          which mapping will occur. Works for entire region
+#                          or subset of countries.
 #
 # Copyright:    (c) 2005-2019 CASAS Global (Center for the Analysis
-#                       of Sustainable Agricultural Systems Global
-#                       https://www.casasglobal.org/).
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -267,10 +267,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -504,7 +504,7 @@ else
     g.region -a res=1000
 fi
 
-# Use various tomato growing areas for masking model output
+# Use various coffee growing areas for masking model output
 if [ "$CROP" == "coffee" ]; then
     r.mapcalc "ElevMask = if ((EtoSelectMask && coffee_HarvestedAreaFraction_colombia > $CROP_THRESHOLD), elevation_1KMmd_GMTEDmd_colombia, null())"
     r.mapcalc "ElevAltMask = if (ElevMask < $ALT, ElevMask, null())"
@@ -771,21 +771,21 @@ for i in $(ls); do
         # need to implement this by developing a raster with state categories
         # currently only works on output raster using 4 steps
         r.report -en map=colombia_departments,MskdModPOS$i units=k,c,p nsteps=4 | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Raster univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Vector univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Raster univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        r.univar map=MskdModPOS$i | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Vector univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
         wait
         if [ "$mapcycle" -eq 1 ]; then
             echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -804,7 +804,7 @@ for i in $(ls); do
                 Plots=0
             fi
         fi
-        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir"/$i.txt
+        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir/$i.txt"
     fi
 
     # If flag -p is checked, then write .rep report files to be plotted.
@@ -812,7 +812,7 @@ for i in $(ls); do
         # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
-        GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
+        GRASS_PNGFILE="$SaveDir/$i-HIST.png"
         export GRASS_PNGFILE
         d.mon start=png
         d.erase
@@ -931,7 +931,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
+++ b/casas_gis_old/casas/grass_scripts/map.pbdm.colombia
@@ -159,7 +159,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -267,15 +267,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
 FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
 
-# Directory with temporary files (see convert.pl script).
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -296,10 +296,10 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=medgold location=latlong_medgold
+    g.mapset mapset=medgold project=latlong_medgold
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
-    g.mapset mapset=medgold location=laea_colombia
+    g.mapset mapset=medgold project=laea_colombia
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=vector pattern="selectedStates"
     g.remove -f type=raster,vector pattern="map*"
@@ -319,7 +319,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -462,7 +462,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=medgold location=latlong_medgold
+g.mapset mapset=medgold project=latlong_medgold
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -479,7 +479,7 @@ for i in $(ls); do
 done
 
 # Change to GRASS location where projected maps are.
-g.mapset mapset=medgold location=laea_colombia
+g.mapset mapset=medgold project=laea_colombia
 
 # Selection of based on vector areas.
 if [ "$DEPARTMENTS" = 'all' ]; then
@@ -525,19 +525,24 @@ max=$(cat ${OUTFILES}/max.txt)
 # Set size of output image.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
+
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
+
 mapcycle=1 # this is just a counter
 # Start interpolation process.
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong_medgold mapset=medgold output=map$i
+    v.proj input=map$i project=latlong_medgold mapset=medgold output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -601,7 +606,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolRaw$i sie=40000 sin=40000 method=bicubic lambda_i=0.01 layer=1 column=$varType
 
         # Constrain interpolated raster within max-min from vector input
@@ -631,7 +636,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -740,7 +746,7 @@ for i in $(ls); do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display scale bar.
-    # d.barscale -l at=50,7
+    # d.barscale at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
@@ -752,7 +758,7 @@ for i in $(ls); do
     d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
-    d.mon stop=PNG
+    d.mon stop=png
 
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"$LEG1".log
@@ -803,14 +809,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -844,7 +851,8 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     d.rast map=GRAY_HR_SR_OB_DR_colombia
     d.vect map=ne_10m_coastline_colombia type=boundary color=150:150:150 width=2
     d.vect map=ne_10m_admin_0_countries_lakes_colombia type=boundary color=128:128:128 width=3
@@ -853,14 +861,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     d.grid -w size=5:0:0 width=2 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=15
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    d.barscale -s at=7,7
-    d.mon stop=PNG
+    d.barscale at=7,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     r.mapcalc 'selectedStates.composite = if(EtoSelectMask, NE1_HR_LC_SR_W_DR.composite_colombia, null())'
     r.colors map=selectedStates.composite raster=NE1_HR_LC_SR_W_DR.composite_colombia
     d.his i=SR_HR_colombia_clip h=selectedStates.composite brighten=5
@@ -873,8 +882,8 @@ else
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
 
     # Display scale bar.
-    d.barscale -s at=7,7
-    d.mon stop=PNG
+    d.barscale at=7,7
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -891,7 +900,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -923,5 +932,6 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -32,7 +32,7 @@
 #
 #		        SPDX-License-Identifier: GPL-2.0-or-later
 #
-#############################################################################
+############################################################################
 
 # %Module
 # % description: Map the output of CASAS models for the conterminous United States, Mexico, and Central America
@@ -154,7 +154,7 @@
 # %flag
 # % guisection: Color rules
 # % key: e
-# % description: Use histogram equalized color rule
+# % description: Use histogram-equalized color rule
 # %end
 
 # %flag
@@ -272,12 +272,15 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/PerlScripts"
-OUTFILES="${HOME}/outfiles"
+PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
 PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR="C:\Windows\Fonts\\"
+FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
+DIRTMP="$HOME/models_temp/"
+
+# export GRASS_OVERWRITE=1
 
 # export GRASS_VERBOSE=1
 
@@ -298,13 +301,13 @@ cleanup() {
     \rm -f ${OUTFILES}/max.txt
     \rm -f ${OUTFILES}/states.txt
     # Remove gis temp files in latlong location
-    g.mapset mapset=luigi location=latlong
+    g.mapset mapset=luigi project=latlong
     g.remove -f type=vector pattern="map*"
     # Remove gis temp files in mapping location
     if [ "$GIS_OPT_STATES" = 'HI' ]; then
-        g.mapset mapset=luigi location=AEA_Hawaii
+        g.mapset mapset=luigi project=AEA_Hawaii
     else
-        g.mapset mapset=luigi location=AEA_US_mex_central_america
+        g.mapset mapset=luigi project=AEA_US_mex_central_america
     fi
     g.remove -f type=vector pattern="voronoi*"
     g.remove -f type=vector pattern="selectedStates"
@@ -325,7 +328,7 @@ exitprocedure() {
     echo 'User break!' >&2
     cleanup
     echo 'Cleaning up temporary files...' >&2
-    d.mon stop=PNG
+    d.mon stop=png
     exit 1
 }
 
@@ -442,7 +445,6 @@ echo "$LON $LAT $PAR $YEAR" > ${OUTFILES}/inputPar.txt
 perl ${PERLSCRIPTS}/printYear.pl "$HOME"
 
 # Run a perl script that gets rid of column names
-#  (not supported in GRASS 6.0)
 perl ${PERLSCRIPTS}/convert.pl "$HOME"
 
 # Do we want to use the same legend range for all maps?
@@ -469,7 +471,7 @@ if [ "$GIS_FLAG_X" -eq 1 ]; then
 fi
 
 # Set environmental variables to import location.
-g.mapset mapset=luigi location=latlong
+g.mapset mapset=luigi project=latlong
 
 # Import model output table into a GRASS vector.
 cd $DIRTMP
@@ -487,9 +489,9 @@ done
 
 # Change to GRASS location where US maps are.
 if [ "$STATES" = 'HI' ]; then
-    g.mapset mapset=luigi location=AEA_Hawaii
+    g.mapset mapset=luigi project=AEA_Hawaii
 else
-    g.mapset mapset=luigi location=AEA_US_mex_central_america
+    g.mapset mapset=luigi project=AEA_US_mex_central_america
 fi
 
 # Transform dummy value for conterminous US.
@@ -599,26 +601,32 @@ fi
 # Write header in the log file.
 echo "This log reports names of input files used for analysis:" | tee -a "$SaveDir"/"${LEG1}".log
 
-# Retrieve range min and max values for possible use in legend drawing. Maybe check if the files exists...
+# Retrieve range min and max values for possible use in legend drawing.
+# Maybe check if the files exists...
 min=$(cat ${OUTFILES}/min.txt)
 max=$(cat ${OUTFILES}/max.txt)
 
 # Set size of output image.
 cd $DIRTMP
 eval $(g.region -g)
-export GRASS_WIDTH=$((cols * FIGRES))
-export GRASS_HEIGHT=$(((rows * 137 * FIGRES) / 100))
-export GRASS_PNG_READ=TRUE
-export GRASS_RENDER_IMMEDIATE=TRUE
-export GRASS_TRUECOLOR=TRUE
+# https://grass.osgeo.org/grass-stable/manuals/variables.html#list-of-selected-grass-environment-variables-for-rendering
+# https://grass.osgeo.org/grass-stable/manuals/pngdriver.html
+export GRASS_RENDER_FILE_READ=TRUE
+export GRASS_RENDER_WIDTH=$((cols * FIGRES))
+# export GRASS_RENDER_HEIGHT=$(( ( rows + 360  ) * FIGRES ))
+export GRASS_RENDER_HEIGHT=$(((rows * 137 * FIGRES) / 100))
+### export GRASS_RENDER_IMMEDIATE=cairo  # or: png, or: d.mon png, used below
+export GRASS_RENDER_TRUECOLOR=TRUE
+
 # Choose a font for figure text.
-export GRASS_FONT='arial'
+export GRASS_FONT='arial'   # the full path to a FreeType font file
+
 mapcycle=1 # this is just a counter
 # Start interpolation process.
 for i in $(ls); do
     # Reproject imported model vectors to current location.
     echo "reprojecting map$i ..."
-    v.proj input=map$i location=latlong mapset=luigi output=map$i
+    v.proj input=map$i project=latlong mapset=luigi output=map$i
 
     # Add a column to vector containing altitudes uploaded from raster DEM.
     v.db.addcol map=map$i columns="elevation INT"
@@ -682,7 +690,7 @@ for i in $(ls); do
         # v.to.rast may be appropriate with PROTHEUS data.
         v.surf.idw -n input=mapPos$i output=interpol$i npoints=$PNTS layer=1 col=$varType # Removed -n flag
     else
-        # http://osgeo-org.1803224.n2.nabble.com/Raster-surface-from-regularly-spaced-points-tp4597143p4597375.html
+        # https://lists.osgeo.org/pipermail/grass-user/2010-February/054868.html
         v.surf.bspline input=mapPos$i raster=interpolRaw$i sie=46000 sin=46000 method=bicubic lambda_i=0.01 layer=1 column=$varType
 
         # Constrain interpolated raster within max-min from vector input
@@ -709,7 +717,8 @@ for i in $(ls); do
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/"$i".png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
 
     # Remove voronoi-related stuff.
     \rm -f ${OUTFILES}/voronoi*.txt
@@ -806,13 +815,13 @@ for i in $(ls); do
                 fi
             fi
         fi
-        # Overalay model raster to a shaded relief and add state
+        # Overlay model raster to a shaded relief and add state
         # boundaries, weather stations, etc.
         # 1) Apply USraster MASK
         # 2) r.neighbors 7x7 window with circular neighborood (i.e. -c flag) on the original DEM
         # [ 3) r.mapcalc "US_dem_resolution_bumped = (US_dem * 0.1) + (US_dem_7x7_smooth * 0.9)" ]
         # (this is supposed to make the shaded relief a bit less fuzzy -- step 3 NOT implemented here)
-        # r.shaded.releif 60/315/10 - done following an idea
+        # r.shaded.relief 60/315/10 - done following an idea
         # from http://www.pdcarto.com/mtncarto02/GRASS.htm
         # https://mountaincartography.icaci.org/mt_hood/pdfs/dunlavey2.pdf
 
@@ -862,7 +871,8 @@ for i in $(ls); do
     else
         d.legend -s map=MskdModPOS$i color=black lines=0 thin=1000 labelnum=5 at=6,10,20,80
         # legend range relative to current map. Old horizontal legend location 10,13.5,10,90
-        # To excluede outliers from legend, the range=min,max option in d.legend
+
+        # To exclude outliers from legend, the range=min,max option in d.legend
         # needs to be enabled in the GIS script MedPresentClimate using
         # the two whiskers of the R box plot (see boxplot.stats() in R).
     fi
@@ -870,7 +880,7 @@ for i in $(ls); do
     # by adding: "use=1000,100,10,0,-10,-100,-1000".
 
     # Display scale bar.
-    # d.barscbarscale -l at=50,7
+    # d.barscale at=50,7
 
     # Display true type font text in the legend (at x-y, lower-left coordinates).
     echo "$LEG1" > ${OUTFILES}/legend1.txt
@@ -882,7 +892,7 @@ for i in $(ls); do
     d.text size=3 color=black at=5,94 input=${OUTFILES}/legend1$mapcycle.txt
 
     # Save display to .png file.
-    d.mon stop=PNG
+    d.mon stop=png
 
     # Write a log with names of input files.
     echo "$i" | tee -a "$SaveDir"/"${LEG1}".log
@@ -939,14 +949,15 @@ for i in $(ls); do
 
     # If flag -p is checked, then write .rep report files to be plotted.
     if [ "$GIS_FLAG_P" -eq 1 ]; then
-        # Not working for now since r.stats is buggy -- TO BE IMPLEMENTED IN R
+        # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
         GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
         export GRASS_PNGFILE
-        d.erase color=white
+        d.mon start=png
+        d.erase
         d.histogram map="MskdModPOS$i"
-        d.mon stop=PNG
+        d.mon stop=png
         # d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=png
         #~ d.out.file output="$SaveDir"/"$i"-HIST res=$FIGRES format=eps
     fi
@@ -981,7 +992,9 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
+
     d.rast map=MSR_50M_land
     d.vect map=world_bounds type=boundary color=150:150:150 width=2
     d.vect map=us_conterm_hawaii_mex_centr_am type=boundary width=4
@@ -995,14 +1008,15 @@ if [ "$GIS_FLAG_G" -eq 1 ]; then
     d.grid -w size=5:0:0 origin=0,0 color=grey bordercolor=black textcolor=black fontsize=15
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=png
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
-    d.barscale -s at=7,7
-    d.mon stop=PNG
+    d.barscale at=7,7
+    d.mon stop=png
 else
     # If flag -g is not checked, output is a color figure (with lakes)
     # Set png file for output.
     GRASS_PNGFILE="$SaveDir"/WeatherStations.png
     export GRASS_PNGFILE
-    d.erase color=white
+    d.mon start=png
+    d.erase
     r.mapcalc 'selectedStates.composite = if(selectedStatesRaster, natural_earth_color.composite, null())'
     r.colors map=selectedStates.composite raster=natural_earth_color.composite
     d.his i=MSR_50M_land h=selectedStates.composite
@@ -1022,9 +1036,9 @@ else
     #~ d.out.file output="$SaveDir"/WeatherStations res=$FIGRES format=eps
 
     # Display scale bar.
-    d.barscale -s at=7,7
+    d.barscale at=7,7
 
-    d.mon stop=PNG
+    d.mon stop=png
 fi
 
 # Set default value with no upper cutting point.
@@ -1041,7 +1055,7 @@ else
 fi
 
 # Write html pages.
-perl ${PERLSCRIPTS}/HtmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
+perl ${PERLSCRIPTS}/htmlSum.pl "$SaveDir" "${LEG1}" "$PAR" "$CUT" "$HICUT" "$ALT" "$SurfCut" "$STATES" "$Plots"
 # If flag -p is checked, then make barchart plots.
 if [ "$GIS_FLAG_P" -eq 1 ]; then
     #~ perl ${PERLSCRIPTS}/makePlotData.pl "$SaveDir"
@@ -1069,9 +1083,13 @@ fi
 mkdir -p ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 
+# Perform final cleanup.
+#~ cleanup
+
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
 firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/casas/grass_scripts/usa
+++ b/casas_gis_old/casas/grass_scripts/usa
@@ -6,31 +6,31 @@
 #
 # AUTHOR(S):    Luigi Ponti quartese gmail com
 #
-# PURPOSE:      Import ASCII ouput files from CASAS models
-#                      to a GRASS monitor after interpolation and
-#                      save the map to an image file (currently png).
+# PURPOSE:      Import ASCII output files from CASAS models
+#               to a GRASS monitor after interpolation and
+#               save the map to an image file (currently png).
 #
 # NOTE:         This version supports outfiles with names of
-#                       type "Olive_02Mar06_00003.txt".
+#               type "Olive_02Mar06_00003.txt".
 #
-#				Updates:
-#				2019-08-30 Added ability to use tomato (various extents)
-#						for clipping model output as a multiple choice
-#						option. Works for entire region or subset of
-#						countries.
-#				2020-06-05 Added ability to select countries in Central
-#						America (Belize, Guatemala, Honduras, El Salvador,
-#                       Nicaragua, Costa Rica, Panama) for use in the fruit
-#                       flies study). Uses a new projected location named
-#                       AEA_US_mex_central_america#
-#				2025-01-21 Added alflafa harvested area to the list of
-#                       crops for clipping model output.
+#               Updates:
+#               2019-08-30 Added ability to use tomato (various extents)
+#                          for clipping model output as a multiple choice
+#                          option. Works for entire region or subset of
+#                          countries.
+#               2020-06-05 Added ability to select countries in Central
+#                          America (Belize, Guatemala, Honduras, El Salvador,
+#                          Nicaragua, Costa Rica, Panama) for use in the fruit
+#                          flies study). Uses a new projected location named
+#                          AEA_US_mex_central_america#
+#               2025-01-21 Added alflafa harvested area to the list of
+#                          crops for clipping model output.
 #
-# Copyright:    (c) 2005-2025 CASAS (Center for the Analysis
-#                       of Sustainable Agricultural Systems
-#                       https://www.casasglobal.org/).
+# Copyright:    (c) 2005-2025 CASAS Global (Center for the Analysis
+#               of Sustainable Agricultural Systems)
+#               https://www.casasglobal.org/).
 #
-#		        SPDX-License-Identifier: GPL-2.0-or-later
+#               SPDX-License-Identifier: GPL-2.0-or-later
 #
 ############################################################################
 
@@ -272,10 +272,10 @@
 # %end
 
 # Set some environmental variables
-PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
-OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
-PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
-FONTDIR='C:\Windows\Fonts\'
+export PERLSCRIPTS="${HOME}/software/casas-gis/casas_gis_old/PerlScripts"
+export OUTFILES="${HOME}/software/casas-gis/casas_gis_old/outfiles"
+export PALETTES="${HOME}/software/casas-gis/casas_gis_old/palettes"
+export FONTDIR='C:\Windows\Fonts\'
 
 # Directory with temporary files (see convert.pl script).
 DIRTMP="$HOME/models_temp/"
@@ -911,21 +911,21 @@ for i in $(ls); do
         # e.g. from vector us_conterm_hawaii_mex_centr_am
         # currently only works on output raster using 4 steps
         r.report -en map=MskdModPOS$i units=k,c,p nsteps=4 | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Raster univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        r.univar map=MskdModPOS$i | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "Vector univariate statistics:" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
-        echo "-------------------------------------------" | tee -a "$SaveDir"/$i.txt
-        echo "" | tee -a "$SaveDir"/$i.txt
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Raster univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        r.univar map=MskdModPOS$i | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "Vector univariate statistics:" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        v.univar -e map=mapPos$i type=point column=$varType | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
+        echo "-------------------------------------------" | tee -a "$SaveDir/$i.txt"
+        echo "" | tee -a "$SaveDir/$i.txt"
         wait
         if [ "$mapcycle" -eq 1 ]; then
             echo 'There is no stat report for weather stations!' > "$SaveDir"/WeatherStations.txt
@@ -944,7 +944,7 @@ for i in $(ls); do
                 Plots=0
             fi
         fi
-        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir"/$i.txt
+        echo 'Sorry, no stat report was requested for this analysis.' > "$SaveDir/$i.txt"
     fi
 
     # If flag -p is checked, then write .rep report files to be plotted.
@@ -952,7 +952,7 @@ for i in $(ls); do
         # Not working for now since G6 r.stats is buggy. -- check for G8
         #~ r.stats -anr input=MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.tot
         #~ r.stats -anr input=regioni_istat,MskdModPOS$i fs=tab nsteps=4 > "$SaveDir"/$i.rep
-        GRASS_PNGFILE="$SaveDir"/"$i"-HIST.png
+        GRASS_PNGFILE="$SaveDir/$i-HIST.png"
         export GRASS_PNGFILE
         d.mon start=png
         d.erase
@@ -1089,7 +1089,7 @@ cp ${OUTFILES}/*.txt ${OUTFILES}/$GIS_OPT_SAVEDIR/data/
 # Set default browser for HTML visual summary.
 GRASS_HTML_BROWSER=firefox.exe
 # Open HTML visual summary.
-firefox.exe "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
-#firefox "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
+$GRASS_HTML_BROWSER "file:///C:/cygwin/home/andy/outfiles/$GIS_OPT_SAVEDIR/${LEG1}.html"
+#$GRASS_HTML_BROWSER "${OUTFILES}/$GIS_OPT_SAVEDIR/${LEG1}.html"
 
 exit 0

--- a/casas_gis_old/scripts/get_boxplot_stats.sh
+++ b/casas_gis_old/scripts/get_boxplot_stats.sh
@@ -35,7 +35,7 @@ divrule="$4" # i.e. divYes or divNo
 percent="$5" # i.e. 0 or 1 (is the var in % scale?)
 
 # Set location and mapset
-g.mapset mapset=$mapsetname location=$locationname
+g.mapset mapset=$mapsetname project=$locationname
 
 # Stats for boxplot from raster data.
 echo "# Raster statistics for raster $RasterMapName #" | tee ~/${RasterMapName}"_stats.txt"

--- a/casas_gis_old/scripts/make_new_GIS_location.sh
+++ b/casas_gis_old/scripts/make_new_GIS_location.sh
@@ -13,7 +13,7 @@
 #~ US_states_Mex world_bounds US_conterm_lakes_wwf
 
 # Change mapset
-g.mapset mapset=luigi2 location=AEA_US
+g.mapset mapset=luigi2 project=AEA_US
 
 # Copy rasters
 g.copy raster=US_dem@luigi,US_dem


### PR DESCRIPTION
This PR updates the GRASS GIS related scripts to GRASS GIS 8 to address

- parameter and flag changes
- updated of PNG driver usage
- consistent usage of PNG driver
- fixed a shell bug with `r.out.gdal ... predictor=3` (was in the following line, hence unused yet uncommented)
- further formatting standardization to address #120: like this the scripts are more easily comparable

It also cross-syncs among the scripts to achieve more similarity in coding style (comparisons done with the visual diff and merge tool [meld](https://meldmerge.org/) in a 1:n shell loop).